### PR TITLE
Replace flexi-streams by the original decoding stream

### DIFF
--- a/dexador.asd
+++ b/dexador.asd
@@ -21,8 +21,8 @@
                :quri
                :fast-io
                :babel
+               :trivial-gray-streams
                :chunga
-               :flexi-streams
                :cl-ppcre
                :cl-cookie
                :trivial-mimes
@@ -37,10 +37,11 @@
                 ((:file "dexador" :depends-on ("backend" "error"))
                  (:file "encoding")
                  (:file "connection-cache")
+                 (:file "decoding-stream")
                  (:file "error")
                  (:file "util")
                  (:module "backend"
-                  :depends-on ("encoding" "connection-cache" "error" "util")
+                  :depends-on ("encoding" "connection-cache" "decoding-stream" "error" "util")
                   :components
                   ((:file "usocket"))))))
   :description "Yet another HTTP client for Common Lisp"

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -7,6 +7,8 @@
   (:import-from :dexador.connection-cache
                 :steal-connection
                 :push-connection)
+  (:import-from :dexador.decoding-stream
+                :make-decoding-stream)
   (:import-from :dexador.error
                 :http-request-failed
                 :http-request-not-found)
@@ -27,8 +29,6 @@
   (:import-from :chunga
                 :chunked-stream-input-chunking-p
                 :make-chunked-stream)
-  (:import-from :flexi-streams
-                :make-flexi-stream)
   (:import-from :trivial-mimes
                 :mime)
   (:import-from :cl-cookie
@@ -227,7 +227,7 @@
     (if charset
         (handler-case
             (if (streamp body)
-                (flex:make-flexi-stream body :external-format charset)
+                (make-decoding-stream body :encoding charset)
                 (babel:octets-to-string body :encoding charset))
           (error (e)
             (warn (format nil "Failed to decode the body to ~S due to the following error (falling back to binary):~%  ~A"

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -341,15 +341,18 @@
                             force-binary
                             want-stream)
   (declare (ignorable ssl-key-file ssl-cert-file ssl-key-password)
-           (type float version))
+           (type single-float version)
+           (type fixnum max-redirects))
   (flet ((make-new-connection (uri)
            (let ((stream
                    (usocket:socket-stream
                     (usocket:socket-connect (uri-host uri)
                                             (uri-port uri)
                                             :timeout timeout
-                                            :element-type '(unsigned-byte 8)))))
-             (if (string= (uri-scheme uri) "https")
+                                            :element-type '(unsigned-byte 8))))
+                 (scheme (uri-scheme uri)))
+             (declare (type string scheme))
+             (if (string= scheme "https")
                  #+dexador-no-ssl
                  (error "SSL not supported. Remove :dexador-no-ssl from *features* to enable SSL.")
                  #-dexador-no-ssl
@@ -361,7 +364,7 @@
          (finalize-connection (stream connection-header uri)
            (if (or want-stream
                    (and keep-alive
-                        (or (and (= version 1.0)
+                        (or (and (= (the single-float version) 1.0)
                                  (equalp connection-header "keep-alive"))
                             (not (equalp connection-header "close")))))
                (push-connection (format nil "~A://~A"
@@ -397,13 +400,14 @@
                         (if header
                             (when (cdr header)
                               (write-header name (cdr header)))
-                            (write-header name value)))))
+                            (write-header name value)))
+                      (values)))
                (with-header-output (buffer)
                  (write-header* :user-agent #.*default-user-agent*)
                  (write-header* :host (uri-authority uri))
                  (write-header* :accept "*/*")
                  (when (and keep-alive
-                            (= version 1.0))
+                            (= (the single-float version) 1.0))
                    (write-header* :connection "keep-alive"))
                  (when basic-auth
                    (write-header* :authorization
@@ -419,13 +423,13 @@
                                    (multipart-content-length content boundary)))
                    (form-urlencoded-p
                     (write-header* :content-type "application/x-www-form-urlencoded")
-                    (write-header* :content-length (length content)))
+                    (write-header* :content-length (length (the string content))))
                    (t
                     (etypecase content
                       (null)
                       (string
                        (write-header* :content-type "text/plain")
-                       (write-header* :content-length (length (babel:string-to-octets content))))
+                       (write-header* :content-length (length (the (simple-array (unsigned-byte 8) *) (babel:string-to-octets content)))))
                       (pathname
                        (write-header* :content-type (mimes:mime content))
                        (if-let ((content-length (assoc :content-length headers :test #'string-equal)))

--- a/src/decoding-stream.lisp
+++ b/src/decoding-stream.lisp
@@ -20,7 +20,8 @@ Similar to flexi-input-stream, except this uses Babel for decoding."))
 (in-package :dexador.decoding-stream)
 
 (declaim (type fixnum +buffer-size+))
-(defconstant +buffer-size+ 128)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defconstant +buffer-size+ 128))
 
 (defclass decoding-stream (fundamental-character-input-stream)
   ((stream :type stream
@@ -30,7 +31,7 @@ Similar to flexi-input-stream, except this uses Babel for decoding."))
    (encoding :initarg :encoding
              :initform (error ":encoding is required")
              :accessor decoding-stream-encoding)
-   (buffer :type (simple-array (unsigned-byte 8) #.+buffer-size+)
+   (buffer :type (simple-array (unsigned-byte 8) (#.+buffer-size+))
            :initform (make-array +buffer-size+ :element-type '(unsigned-byte 8))
            :accessor decoding-stream-buffer)
    (buffer-position :type fixnum

--- a/src/decoding-stream.lisp
+++ b/src/decoding-stream.lisp
@@ -59,18 +59,16 @@ Similar to flexi-input-stream, except this uses Babel for decoding."))
     (declare (type (simple-array (unsigned-byte 8) (#.+buffer-size+)) buffer)
              (type fixnum buffer-position))
     (let ((to-read (- +buffer-size+ buffer-position)))
+      (declare (type fixnum to-read))
       (replace buffer buffer
                :start1 0
                :start2 buffer-position
                :end2 +buffer-size+)
       (setf buffer-position 0)
-      (loop for byte = (read-byte stream nil nil)
-            for i from to-read to (1- +buffer-size+)
-            if byte
-              do (setf (aref buffer i) byte)
-            else
-              do (setf buffer-end-position i)
-                 (return)))))
+      (let ((n (read-sequence buffer stream :start to-read)))
+        (declare (type fixnum n))
+        (unless (= n +buffer-size+)
+          (setf buffer-end-position n))))))
 
 (defun needs-to-fill-buffer-p (stream)
   (declare (optimize speed))

--- a/src/decoding-stream.lisp
+++ b/src/decoding-stream.lisp
@@ -1,0 +1,115 @@
+(in-package :cl-user)
+(defpackage dexador.decoding-stream
+  (:use :cl)
+  (:import-from :trivial-gray-streams
+                :fundamental-character-input-stream
+                :stream-read-char)
+  (:import-from :babel
+                :*string-vector-mappings*
+                :unicode-char)
+  (:import-from :babel-encodings
+                :*default-character-encoding*
+                :get-character-encoding
+                :code-point-counter
+                :enc-max-units-per-char
+                :lookup-mapping)
+  (:export :make-decoding-stream
+           :decoding-stream)
+  (:documentation "Provides character decoding stream.
+Similar to flexi-input-stream, except this uses Babel for decoding."))
+(in-package :dexador.decoding-stream)
+
+(declaim (type fixnum +buffer-size+))
+(defconstant +buffer-size+ 128)
+
+(defclass decoding-stream (fundamental-character-input-stream)
+  ((stream :type stream
+           :initarg :stream
+           :initform (error ":stream is required")
+           :accessor decoding-stream-stream)
+   (encoding :initarg :encoding
+             :initform (error ":encoding is required")
+             :accessor decoding-stream-encoding)
+   (buffer :type (simple-array (unsigned-byte 8) #.+buffer-size+)
+           :initform (make-array +buffer-size+ :element-type '(unsigned-byte 8))
+           :accessor decoding-stream-buffer)
+   (buffer-position :type fixnum
+                    :initform +buffer-size+
+                    :accessor decoding-stream-buffer-position)
+   (buffer-end-position :type fixnum
+                        :initform -1
+                        :accessor decoding-stream-buffer-end-position)))
+
+(defmethod initialize-instance :after ((stream decoding-stream) &rest initargs)
+  (declare (ignore initargs))
+  (with-slots (encoding) stream
+    (when (keywordp encoding)
+      (setf encoding (get-character-encoding encoding)))))
+
+(defun make-decoding-stream (stream &key (encoding babel-encodings:*default-character-encoding*))
+  (let ((decoding-stream (make-instance 'decoding-stream
+                                        :stream stream
+                                        :encoding encoding)))
+    (fill-buffer decoding-stream)
+    decoding-stream))
+
+(defun fill-buffer (stream)
+  (declare (optimize speed))
+  (with-slots (stream buffer buffer-position buffer-end-position) stream
+    (declare (type (simple-array (unsigned-byte 8) (#.+buffer-size+)) buffer)
+             (type fixnum buffer-position))
+    (let ((to-read (- +buffer-size+ buffer-position)))
+      (replace buffer buffer
+               :start1 0
+               :start2 buffer-position
+               :end2 +buffer-size+)
+      (setf buffer-position 0)
+      (loop for byte = (read-byte stream nil nil)
+            for i from to-read to (1- +buffer-size+)
+            if byte
+              do (setf (aref buffer i) byte)
+            else
+              do (setf buffer-end-position i)
+                 (return)))))
+
+(defun needs-to-fill-buffer-p (stream)
+  (declare (optimize speed))
+  (when (/= -1 (the fixnum (decoding-stream-buffer-end-position stream)))
+    (return-from needs-to-fill-buffer-p nil))
+
+  (with-slots (buffer-position encoding) stream
+    (< (- +buffer-size+ (the fixnum buffer-position))
+       (the fixnum (enc-max-units-per-char encoding)))))
+
+(defmethod stream-read-char ((stream decoding-stream))
+  (declare (optimize speed))
+  (when (needs-to-fill-buffer-p stream)
+    (fill-buffer stream))
+
+  (when (= (the fixnum (decoding-stream-buffer-end-position stream))
+           (the fixnum (decoding-stream-buffer-position stream)))
+    (return-from stream-read-char :eof))
+
+  (with-slots (buffer buffer-position encoding) stream
+    (let* ((mapping (lookup-mapping *string-vector-mappings* encoding))
+           (counter (code-point-counter mapping)))
+      (declare (type function counter))
+      (multiple-value-bind (size new-end)
+          (funcall counter buffer buffer-position +buffer-size+ 1)
+        (declare (ignore size))
+        (let ((string (make-string 1 :element-type 'babel:unicode-char)))
+          (funcall (the function (babel-encodings:decoder mapping))
+                   buffer buffer-position new-end string 0)
+          (setf buffer-position new-end)
+          (aref string 0))))))
+
+(defmethod open-stream-p ((stream decoding-stream))
+  (open-stream-p (decoding-stream-stream stream)))
+
+(defmethod stream-element-type ((stream decoding-stream))
+  'unicode-char)
+
+(defmethod close ((stream decoding-stream) &key abort)
+  (with-slots (stream) stream
+    (when (open-stream-p stream)
+      (close stream :abort abort))))

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -185,11 +185,22 @@ body: \"Within a couple weeks of learning Lisp I found programming in any other 
     (lambda (env)
       (declare (ignore env))
       '(200 (:content-type "text/plain") ("hi")))
+  ;; decoding stream
   (let ((body (dex:get "http://localhost:4242/" :want-stream t :keep-alive nil)))
-    (is-type body 'stream)
+    (is-type body 'dexador.decoding-stream:decoding-stream
+             "body is a decoding stream")
+    (is (stream-element-type body) 'babel:unicode-char
+        "body is a character stream")
+    (let ((buf (make-string 2)))
+      (read-sequence buf body)
+      (is buf "hi")))
+  ;; binary stream
+  (let ((body (dex:get "http://localhost:4242/" :want-stream t :force-binary t :keep-alive nil)))
+    (is-type body 'stream "body is a stream")
+    (is (stream-element-type body) '(unsigned-byte 8)
+        "body is a octets stream")
     (let ((buf (make-array 2 :element-type '(unsigned-byte 8))))
       (read-sequence buf body)
-      (is (babel:octets-to-string buf) "hi"))
-    (ignore-errors (close body))))
+      (is (babel:octets-to-string buf) "hi"))))
 
 (finalize)


### PR DESCRIPTION
This adds "decoding-stream". Though it's similar to flexi-streams, it uses Babel for decoding characters.