### PR TITLE
ignore content-length when transfer-encoding set

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -168,7 +168,7 @@
        (setq body stream))
       ((not has-body)
        (setq body +empty-body+))
-      (content-length
+      ((and content-length (not transfer-encoding-p))
        (let ((buf (make-array content-length :element-type '(unsigned-byte 8))))
          (read-sequence buf stream)
          (setq body buf)))
@@ -243,12 +243,12 @@
   (when (and (streamp body)
              keep-alive-p)
     (cond
-      (content-length
-       (setf body
-              (make-keep-alive-stream body :end content-length)))
       (chunkedp
        (setf body
-             (make-keep-alive-stream body :chunked t)))))
+             (make-keep-alive-stream body :chunked t)))
+      (content-length
+       (setf body
+              (make-keep-alive-stream body :end content-length)))))
   (let ((body (decompress-body content-encoding
                                (if (and (streamp body)
                                         chunkedp)


### PR DESCRIPTION
from [RFC2616#4.4](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4):
> If the message does include a non- identity transfer-coding, the Content-Length MUST be ignored.

Currently, Dexador uses Content-Length even when Transfer-Encoding is set -- It ignores Transfer-Encoding if Content-Encoding is set.

RFC 2616 section 4.4 says it should be the opposite, ignoring Content-Length when Transfer-Encoding is set.

This PR fixes this issue.