### PR TITLE
Fix SSLv3 handshake failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
 
 install:
   # Roswell
-  - curl -L https://raw.githubusercontent.com/snmsts/roswell/master/scripts/install-for-ci.sh | sh
+  - curl -L https://raw.githubusercontent.com/roswell/roswell/release/scripts/install-for-ci.sh | sh
   # nginx
   - curl -L http://nginx.org/download/nginx-1.8.0.tar.gz | tar xzf -
   - (cd nginx-1.8.0 && ./configure --prefix=$HOME/nginx && make && make install)

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -381,6 +381,7 @@
                    (error "SSL not supported. Remove :dexador-no-ssl from *features* to enable SSL.")
                    #-dexador-no-ssl
                    (cl+ssl:make-ssl-client-stream stream
+                                                  :hostname (uri-host uri)
                                                   :certificate ssl-cert-file
                                                   :key ssl-key-file
                                                   :password ssl-key-password)


### PR DESCRIPTION
```
A failure in the SSL library occurred on handle #.(SB-SYS:INT-SAP #X7FFFE47F25E0) (return code: 1).
SSL error queue:
error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure
   [Condition of type CL+SSL::SSL-ERROR-SSL]
```