### PR TITLE
Fix: finalize connections with 3xx redirection and connection close

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -638,9 +638,11 @@
                            (setq cookie-headers (build-cookie-headers uri cookie-jar)))
                          (decf max-redirects)
                          (if (equalp (gethash "connection" response-headers) "close")
-                             (setq use-connection-pool nil
-                                   reusing-stream-p nil
-                                   stream (make-new-connection uri))
+                             (progn
+                               (finalize-connection stream (gethash "connection" response-headers) uri)
+                               (setq use-connection-pool nil
+                                     reusing-stream-p nil
+                                     stream (make-new-connection uri)))
                              (setq reusing-stream-p t))
                          (go retry))
                        (progn


### PR DESCRIPTION
Previously, when a server returns a 301/302/303/307 and requests the connection to be closed, a new connection was getting created but the old connection was getting leaked.
This change just finalizes the old connection before creating the new one.