### PR TITLE
Allow overriding content-type header when sending requests

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -450,6 +450,10 @@
            (content (if form-urlencoded-p
                         (quri:url-encode-params content)
                         content))
+           (content-type
+             (loop for (name . value) in headers do
+               (when (eq name :content-type)
+                 (return value))))
            (stream (or stream
                        (and use-connection-pool
                             (steal-connection (format nil "~A://~A"
@@ -496,6 +500,8 @@
                                                    (car basic-auth)
                                                    (cdr basic-auth))))))
                  (cond
+                   (content-type
+                    (write-header* :content-type content-type))
                    (multipart-p
                     (write-header* :content-type (format nil "multipart/form-data; boundary=~A" boundary))
                     (unless chunkedp


### PR DESCRIPTION
For sending e.g. JSON payloads with POST requests, one needs to set
the proper content type (in this case, "application/json"). Currently,
this is not possible because this header is filtered out and dexador
tries to set it automatically, which does not work in these scenarios.

This patch allows to override the content type manually. If not present,
dexador will still try to guess it automatically.