### PR TITLE
Allow providing content-length for custom content-type

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -501,7 +501,9 @@
                                                    (cdr basic-auth))))))
                  (cond
                    (content-type
-                    (write-header* :content-type content-type))
+                    (write-header* :content-type content-type)
+                    (if-let ((content-length (assoc :content-length headers :test #'string-equal)))
+		      (write-header* :content-length (cdr content-length))))
                    (multipart-p
                     (write-header* :content-type (format nil "multipart/form-data; boundary=~A" boundary))
                     (unless chunkedp


### PR DESCRIPTION
Some APIs (e.g. Amazon DynamoDB) require content-length field in request but
it's not added now when custom content-type is set.
This behaviour breaks some packages, like [dyna](https://github.com/Rudolph-Miller/dyna/issues/41).
The patch adds the header field if the content-length value is available.