### PR TITLE
non-empty bodies in responses w/o declared body length (solves #52)

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -182,12 +182,11 @@
        (let ((buf (make-array content-length :element-type '(unsigned-byte 8))))
          (read-sequence buf stream)
          (setq body buf)))
-      ((or (not transfer-encoding-p)
-           (let ((status (http-status http)))
-             (or (= status 100)    ;; Continue
-                 (= status 101)    ;; Switching Protocols
-                 (= status 204)    ;; No Content
-                 (= status 304)))) ;; Not Modified
+      ((let ((status (http-status http)))
+         (or (= status 100)    ;; Continue
+             (= status 101)    ;; Switching Protocols
+             (= status 204)    ;; No Content
+             (= status 304))) ;; Not Modified
        (setq body +empty-body+))
       (T
        (setq body-data (make-output-buffer))


### PR DESCRIPTION
Allows non-empty bodies in responses without either "Content-Length" or "Transfer-Encoding".
This is allowed by [RFC7230](https://tools.ietf.org/html/rfc7230#section-3.3.3): https://tools.ietf.org/html/rfc7230#section-3.3.3
(mainly item 7)