### PR TITLE
Fix stream close_wait state

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -547,6 +547,7 @@
                         (handler-bind ((error
                                          (lambda (e)
                                            (declare (ignore e))
+                                           (ignore-errors (close stream))
                                            (when reusing-stream-p
                                              (setf use-connection-pool nil
                                                    reusing-stream-p nil


### PR DESCRIPTION
Long visits to the site can result in a large number of streams that are not closed properly when reusing-stream-p is true