### PR TITLE
allow proxy authentication

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -499,6 +499,13 @@
                                            (format nil "~A:~A"
                                                    (car basic-auth)
                                                    (cdr basic-auth))))))
+                 (when proxy
+                   (let* ((uri (quri:uri proxy))
+                          (proxy-auth (quri:uri-userinfo uri)))
+                     (when proxy-auth
+                       (write-header* :proxy-authorization
+                                      (format nil "Basic ~A"
+                                              (string-to-base64-string proxy-auth))))))
                  (cond
                    (multipart-p
                     (write-header* :content-type (format nil "multipart/form-data; boundary=~A" boundary))

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -361,13 +361,19 @@
          buffer)
         (fast-write-sequence +crlf+ buffer)))))
 
-(defun make-connect-stream (uri version stream)
+(defun make-connect-stream (uri version stream &optional proxy-auth)
   (let ((header (with-fast-output (buffer)
-                  (write-connect-header uri version buffer))))
+                  (write-connect-header uri version buffer proxy-auth))))
     (write-sequence header stream)
     (force-output stream)
     (read-until-crlf*2 stream)
     stream))
+
+(defun make-proxy-authorization (uri)
+  (let ((proxy-auth (quri:uri-userinfo uri)))
+    (when proxy-auth
+      (format nil "Basic ~A"
+              (string-to-base64-string proxy-auth)))))
 
 (defun-careful request (uri &rest args
                             &key (method :get) (version 1.1)
@@ -416,7 +422,7 @@
                                                            (t :default)))))
                            (cl+ssl:with-global-context (ctx :auto-free-p t)
                              (cl+ssl:make-ssl-client-stream (if proxy
-                                                                (make-connect-stream uri version stream)
+                                                                (make-connect-stream uri version stream (make-proxy-authorization con-uri))
                                                                 stream)
                                                             :hostname (uri-host uri)
                                                             :verify (not insecure)
@@ -500,12 +506,12 @@
                                                    (car basic-auth)
                                                    (cdr basic-auth))))))
                  (when proxy
-                   (let* ((uri (quri:uri proxy))
-                          (proxy-auth (quri:uri-userinfo uri)))
-                     (when proxy-auth
-                       (write-header* :proxy-authorization
-                                      (format nil "Basic ~A"
-                                              (string-to-base64-string proxy-auth))))))
+                   (let ((scheme (quri:uri-scheme uri)))
+                     (when (string= scheme "http")
+                       (let* ((uri (quri:uri proxy))
+                              (proxy-authorization (make-proxy-authorization uri)))
+                         (when proxy-authorization
+                           (write-header* :proxy-authorization proxy-authorization))))))
                  (cond
                    (multipart-p
                     (write-header* :content-type (format nil "multipart/form-data; boundary=~A" boundary))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -141,7 +141,7 @@
      (let ((*header-buffer* ,buffer))
        ,@body)))
 
-(defun write-connect-header (uri version buffer)
+(defun write-connect-header (uri version buffer &optional proxy-auth)
   (fast-write-sequence (ascii-string-to-octets "CONNECT") buffer)
   (fast-write-byte #.(char-code #\Space) buffer)
   (fast-write-sequence (ascii-string-to-octets (format nil "~A:~A"
@@ -160,6 +160,11 @@
                                                        (uri-host uri)
                                                        (uri-port uri)))
                        buffer)
+  (when proxy-auth
+    (fast-write-sequence +crlf+ buffer)
+    (fast-write-sequence (ascii-string-to-octets "Proxy-Authorization:") buffer)
+    (fast-write-byte #.(char-code #\Space) buffer)
+    (fast-write-sequence (ascii-string-to-octets proxy-auth) buffer))
   (fast-write-sequence +crlf+ buffer)
   (fast-write-sequence +crlf+ buffer))
 


### PR DESCRIPTION
ref #7, #26 

If a proxy server required authentication, use `:proxy` with `username` and `password`.

```commonlisp
(dex:get "https://beta.quicklisp.org/quicklisp.lisp"
         :proxy "http://user:pass@proxy:8080")
```

I tested in https://github.com/tamurashingo/dexador/tree/feature/proxyauth-travisci
and result is https://travis-ci.org/tamurashingo/dexador/jobs/429888094#L4055

