### PR TITLE
Fix example code

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -185,8 +185,9 @@ Dexador singals a condition `http-request-failed` when the server returned 4xx o
   (dex:get "http://lisp.org"))
 
 ;; Retry 5 times
-(handler-bind ((dex:http-request-failed (dex:retry-request 5 :interval 3)))
-  (dex:get "http://lisp.org"))
+(let ((retry-request (dex:retry-request 5 :interval 3)))
+  (handler-bind ((dex:http-request-failed retry-request))
+    (dex:get "http://lisp.org")))
 ```
 
 ### Proxy


### PR DESCRIPTION
```dex:retry-request``` returns a sideeffect-full closure, and it should be evaled once.

The example code's comments says "Retry 5 times", but it runs retry forever.