### PR TITLE
WinHTTP backend implementation

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,34 @@
+name: CI (Windows)
+
+on: [push]
+
+jobs:
+  test:
+    name: ${{ matrix.lisp }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        lisp: [sbcl-bin]
+        os: [windows-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Roswell
+        shell: bash
+        run: |
+          curl -L https://github.com/roswell/roswell/releases/download/v19.08.10.101/roswell_19.08.10.101_i686.zip -o roswell.zip
+          unzip roswell.zip -d /c/
+          /c/roswell/ros setup
+      - name: Install Rove
+        shell: bash
+        run: /c/roswell/ros install fukamachi/rove/fix/resolve-file-device
+      - name: Install dependencies
+        shell: bash
+        run: |
+          /c/roswell/ros install fukamachi/clack
+          /c/roswell/ros install fukamachi/fast-http
+          /c/roswell/ros install fukamachi/cl-cookie
+      - name: Run tests
+        shell: bash
+        run: |
+          /c/roswell/ros -S . -s rove -e '(or (rove:run :dexador-test) (uiop:quit -1))'

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -21,7 +21,7 @@ jobs:
           /c/roswell/ros setup
       - name: Install Rove
         shell: bash
-        run: /c/roswell/ros install fukamachi/rove/fix/resolve-file-device
+        run: /c/roswell/ros install fukamachi/rove
       - name: Install dependencies
         shell: bash
         run: |
@@ -31,4 +31,5 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          /c/roswell/ros -S . -s rove -e '(or (rove:run :dexador-test) (uiop:quit -1))'
+          PATH="~/.roswell/bin:$PATH"
+          /c/roswell/ros -S . rove dexador-test.asd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on: [push]
+
+jobs:
+  test:
+    name: ${{ matrix.lisp }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        lisp: [sbcl-bin]
+        os: [ubuntu-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Roswell
+        env:
+          LISP: ${{ matrix.lisp }}
+        run: |
+          curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh
+      - name: Install Rove
+        run: ros install rove
+      - name: Install dependencies
+        run: |
+          ros install fukamachi/clack
+          ros install fukamachi/fast-http
+      - name: Run tests
+        run: |
+          PATH="~/.roswell/bin:$PATH"
+          rove dexador-test.asd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,14 @@ jobs:
     strategy:
       matrix:
         lisp: [sbcl-bin]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v1
       - name: Install Roswell
         env:
           LISP: ${{ matrix.lisp }}
+          ROSWELL_INSTALL_DIR: /usr
         run: |
           curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh
       - name: Install Rove
@@ -24,7 +25,12 @@ jobs:
         run: |
           ros install fukamachi/clack
           ros install fukamachi/fast-http
-      - name: Run tests
+      - name: Run tests (Linux, Mac)
         run: |
           PATH="~/.roswell/bin:$PATH"
           rove dexador-test.asd
+        if: matrix.os != 'windows-latest'
+      - name: Run tests (Windows)
+        run: |
+          ros %userprofile%\.roswell\bin\rove dexador-test.asd
+        if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,13 @@ jobs:
     strategy:
       matrix:
         lisp: [sbcl-bin]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest]
 
     steps:
       - uses: actions/checkout@v1
       - name: Install Roswell
         env:
           LISP: ${{ matrix.lisp }}
-          ROSWELL_INSTALL_DIR: /usr
         run: |
           curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh
       - name: Install Rove
@@ -25,12 +24,7 @@ jobs:
         run: |
           ros install fukamachi/clack
           ros install fukamachi/fast-http
-      - name: Run tests (Linux, Mac)
+      - name: Run tests
         run: |
           PATH="~/.roswell/bin:$PATH"
           rove dexador-test.asd
-        if: matrix.os != 'windows-latest'
-      - name: Run tests (Windows)
-        run: |
-          ros %userprofile%\.roswell\bin\rove dexador-test.asd
-        if: matrix.os == 'windows-latest'

--- a/dexador.asd
+++ b/dexador.asd
@@ -26,6 +26,7 @@
                "cl-reexport"
                (:feature (:not :windows) "usocket")
                (:feature :windows "winhttp")
+               (:feature :windows "flexi-streams")
                (:feature (:and (:not :windows) (:not :dexador-no-ssl)) "cl+ssl")
                "bordeaux-threads"
                "alexandria")

--- a/dexador.asd
+++ b/dexador.asd
@@ -11,8 +11,8 @@
   :version "0.9.10"
   :author "Eitaro Fukamachi"
   :license "MIT"
-  :depends-on ("usocket"
-               "fast-http"
+  :defsystem-depends-on ("trivial-features")
+  :depends-on ("fast-http"
                "quri"
                "fast-io"
                "babel"
@@ -24,7 +24,9 @@
                "chipz"
                "cl-base64"
                "cl-reexport"
-               (:feature (:not :dexador-no-ssl) "cl+ssl")
+               (:feature (:not :windows) "usocket")
+               (:feature :windows "winhttp")
+               (:feature (:and (:not :windows) (:not :dexador-no-ssl)) "cl+ssl")
                "bordeaux-threads"
                "alexandria")
   :components ((:module "src"
@@ -34,12 +36,14 @@
                  (:file "connection-cache")
                  (:file "decoding-stream")
                  (:file "keep-alive-stream")
+                 (:file "body" :depends-on ("encoding" "decoding-stream" "util"))
                  (:file "error")
                  (:file "util")
                  (:module "backend"
-                  :depends-on ("encoding" "connection-cache" "decoding-stream" "keep-alive-stream" "error" "util")
+                  :depends-on ("encoding" "connection-cache" "decoding-stream" "keep-alive-stream" "body" "error" "util")
                   :components
-                  ((:file "usocket"))))))
+                  ((:file "usocket" :if-feature (:not :windows))
+                   (:file "winhttp" :if-feature :windows))))))
   :description "Yet another HTTP client for Common Lisp"
   :long-description #.(read-file-string (subpathname *load-pathname* "README.markdown"))
   :in-order-to ((test-op (test-op "dexador-test"))))

--- a/dexador.asd
+++ b/dexador.asd
@@ -43,7 +43,7 @@
                  (:module "backend"
                   :depends-on ("encoding" "connection-cache" "decoding-stream" "keep-alive-stream" "body" "error" "util")
                   :components
-                  ((:file "usocket" :if-feature (:not :windows))
+                  ((:file "usocket")
                    (:file "winhttp" :if-feature :windows))))))
   :description "Yet another HTTP client for Common Lisp"
   :long-description #.(read-file-string (subpathname *load-pathname* "README.markdown"))

--- a/dexador.asd
+++ b/dexador.asd
@@ -24,7 +24,7 @@
                "chipz"
                "cl-base64"
                "cl-reexport"
-               (:feature (:not :windows) "usocket")
+               "usocket"
                (:feature :windows "winhttp")
                (:feature :windows "flexi-streams")
                (:feature (:and (:not :windows) (:not :dexador-no-ssl)) "cl+ssl")

--- a/dexador.asd
+++ b/dexador.asd
@@ -46,5 +46,4 @@
                   ((:file "usocket")
                    (:file "winhttp" :if-feature :windows))))))
   :description "Yet another HTTP client for Common Lisp"
-  :long-description #.(read-file-string (subpathname *load-pathname* "README.markdown"))
   :in-order-to ((test-op (test-op "dexador-test"))))

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -542,7 +542,7 @@
                               (null (cdr content-length)))))
            (first-line-data
              (with-fast-output (buffer)
-               (write-first-line method uri proxy version buffer)))
+               (write-first-line method uri version buffer)))
            (headers-data
              (flet ((write-header* (name value)
                       (let ((header (assoc name headers :test #'string-equal)))
@@ -734,7 +734,7 @@
                          (setq uri (merge-uris location-uri uri))
                          (setq first-line-data
                                (with-fast-output (buffer)
-                                 (write-first-line method uri proxy version buffer)))
+                                 (write-first-line method uri version buffer)))
                          (when cookie-jar
                            ;; Rebuild cookie-headers.
                            (setq cookie-headers (build-cookie-headers uri cookie-jar)))

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -11,6 +11,8 @@
                 :make-decoding-stream)
   (:import-from :dexador.keep-alive-stream
                 :make-keep-alive-stream)
+  (:import-from :dexador.body
+                :decompress-body)
   (:import-from :dexador.error
                 :http-request-failed
                 :http-request-not-found
@@ -50,10 +52,6 @@
                 :url-encode
                 :url-encode-params
                 :merge-uris)
-  (:import-from :chipz
-                :make-decompressing-stream
-                :decompress
-                :make-dstate)
   (:import-from :cl-base64
                 :string-to-base64-string)
   #-dexador-no-ssl
@@ -221,21 +219,6 @@
                  (princ (code-char byte)))
            d))
     (boundary-line)))
-
-(defun decompress-body (content-encoding body)
-  (unless content-encoding
-    (return-from decompress-body body))
-
-  (cond
-    ((string= content-encoding "gzip")
-     (if (streamp body)
-         (chipz:make-decompressing-stream :gzip body)
-         (chipz:decompress nil (chipz:make-dstate :gzip) body)))
-    ((string= content-encoding "deflate")
-     (if (streamp body)
-         (chipz:make-decompressing-stream :zlib body)
-         (chipz:decompress nil (chipz:make-dstate :zlib) body)))
-    (T body)))
 
 (defun decode-body (content-type body &key default-charset)
   (let ((charset (or (and content-type

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -12,7 +12,8 @@
   (:import-from :dexador.keep-alive-stream
                 :make-keep-alive-stream)
   (:import-from :dexador.body
-                :decompress-body)
+                :decompress-body
+                :decode-body)
   (:import-from :dexador.error
                 :http-request-failed
                 :http-request-not-found
@@ -219,23 +220,6 @@
                  (princ (code-char byte)))
            d))
     (boundary-line)))
-
-(defun decode-body (content-type body &key default-charset)
-  (let ((charset (or (and content-type
-                          (detect-charset content-type body))
-                     default-charset))
-        (babel-encodings:*suppress-character-coding-errors* t))
-    (if charset
-        (handler-case
-            (if (streamp body)
-                (make-decoding-stream body :encoding charset)
-                (babel:octets-to-string body :encoding charset))
-          (babel:character-decoding-error (e)
-            (warn (format nil "Failed to decode the body to ~S due to the following error (falling back to binary):~%  ~A"
-                          charset
-                          e))
-            (return-from decode-body body)))
-        body)))
 
 (defun convert-body (body content-encoding content-type content-length chunkedp force-binary force-string keep-alive-p)
   (when (and (streamp body)

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -55,7 +55,7 @@
                 :merge-uris)
   (:import-from :cl-base64
                 :string-to-base64-string)
-  #-dexador-no-ssl
+  #-(or windows dexador-no-ssl)
   (:import-from :cl+ssl
                 :with-global-context
                 :make-context
@@ -457,9 +457,9 @@
                    (when (socks5-proxy-p proxy-uri)
                      (ensure-socks5-connected stream stream uri method))
                    (if (string= scheme "https")
-                       #+dexador-no-ssl
+                       #+(or windows dexador-no-ssl)
                        (error "SSL not supported. Remove :dexador-no-ssl from *features* to enable SSL.")
-                       #-dexador-no-ssl
+                       #-(or windows dexador-no-ssl)
                        (progn
                          (cl+ssl:ensure-initialized)
                          (let ((ctx (cl+ssl:make-context :verify-mode

--- a/src/backend/winhttp.lisp
+++ b/src/backend/winhttp.lisp
@@ -71,7 +71,7 @@
               (finish-output-stream stream))
             (format nil "multipart/form-data; boundary=~A" boundary)))
          (values
-          (quri:url-encode-params content)
+          (babel:string-to-octets (quri:url-encode-params content))
           "application/x-www-form-urlencoded")))
     (string (values (babel:string-to-octets content)
                     "text/plain"))

--- a/src/backend/winhttp.lisp
+++ b/src/backend/winhttp.lisp
@@ -1,0 +1,186 @@
+(defpackage #:dexador.backend.winhttp
+  (:nicknames :dex.winhttp)
+  (:use #:cl
+        #:dexador.util
+        #:winhttp)
+  (:import-from #:dexador.body
+                #:decode-body
+                #:write-multipart-content)
+  (:import-from #:dexador.error
+                #:http-request-failed)
+  (:import-from #:winhttp
+                #:set-ignore-certificates
+                #:set-timeouts)
+  (:import-from #:fast-io
+                #:fast-output-stream
+                #:finish-output-stream)
+  (:import-from #:alexandria
+                #:read-file-into-byte-vector)
+  (:import-from #:split-sequence
+                #:split-sequence)
+  (:export :request
+
+           ;; Restarts
+           :retry-request
+           :ignore-and-continue))
+(in-package #:dexador.backend.winhttp)
+
+(defconstant +WINHTTP_OPTION_DISABLE_FEATURE+ 63)
+(defconstant +WINHTTP_DISABLE_COOKIES+    #x00000001)
+(defconstant +WINHTTP_DISABLE_REDIRECTS+  #x00000002)
+(defconstant +WINHTTP_DISABLE_KEEP_ALIVE+ #x00000008)
+
+(defun set-option (req var value &optional (type :uint32))
+  (cffi:with-foreign-object (buf type)
+    (setf (cffi:mem-aref buf type) value)
+    (let ((ret (winhttp::%set-option req
+                                     var
+                                     buf
+                                     (cffi:foreign-type-size type))))
+      (unless ret
+        (winhttp::get-last-error)))))
+
+(defun query-headers* (req)
+  (loop with hash = (make-hash-table :test 'equal)
+        for (name-camelcased value) in (query-headers req)
+        for name = (string-downcase name-camelcased)
+        if (gethash name hash)
+          do (setf (gethash name hash)
+                   (format nil "~A, ~A" (gethash name hash) value))
+        else
+          do (setf (gethash name hash) value)
+        finally (return hash)))
+
+(defun convert-content (content)
+  (etypecase content
+    (cons
+     (if (find-if #'pathnamep content :key #'cdr)
+         (let ((boundary (make-random-string 12)))
+           (values
+            (let ((stream (make-instance 'fast-output-stream)))
+              (write-multipart-content content boundary stream)
+              (finish-output-stream stream))
+            (format nil "multipart/form-data; boundary=~A" boundary)))
+         (values
+          (quri:url-encode-params content)
+          "application/x-www-form-urlencoded")))
+    (string (values (babel:string-to-octets content)
+                    "text/plain"))
+    (pathname (values (read-file-into-byte-vector content)
+                      (mimes:mime content)))
+    ((array (unsigned-byte 8) (*)) content)
+    (null (make-array 0 :element-type '(unsigned-byte 8)))))
+
+;; TODO: Try asynchronous
+(defun request (uri &rest args
+                            &key (method :get) (version 1.1)
+                            content headers
+                            basic-auth
+                            cookie-jar
+                            (timeout *default-timeout*) (keep-alive t) (use-connection-pool t)
+                            (max-redirects 5)
+                            ssl-key-file ssl-cert-file ssl-key-password
+                            stream (verbose *verbose*)
+                            force-binary
+                            want-stream
+                            proxy
+                            (insecure *not-verify-ssl*)
+                            ca-path)
+  (declare (ignore version basic-auth cookie-jar use-connection-pool
+                   ssl-key-file ssl-cert-file ssl-key-password
+                   stream verbose
+                   want-stream proxy
+                   ca-path))
+  (let ((uri (quri:uri uri))
+        (content-type
+          (find :content-type headers :key #'car :test #'eq)))
+    (multiple-value-bind (content detected-content-type) (convert-content content)
+      (when (and (null content-type)
+                 detected-content-type)
+        (setf headers (append `(("Content-Type" . ,detected-content-type)) headers)))
+      (with-http (session)
+        (with-connect (conn session (quri:uri-host uri) (quri:uri-port uri))
+          (with-request (req conn :verb method
+                                  :url (format nil "~@[~A~]~@[?~A~]"
+                                               (quri:uri-path uri)
+                                               (quri:uri-query uri))
+                                  :https-p (equalp (quri:uri-scheme uri) "https"))
+            (when (quri:uri-userinfo uri)
+              (destructuring-bind (user pass) (split-sequence #\: (quri:uri-userinfo uri))
+                (set-credentials req user pass)))
+
+            ;; TODO: cookie support
+            ;; TODO: SSL arguments
+            ;; TODO: proxy support
+            (set-option req
+                        +WINHTTP_OPTION_DISABLE_FEATURE+
+                        (logior +WINHTTP_DISABLE_COOKIES+
+                                +WINHTTP_DISABLE_REDIRECTS+
+                                (if keep-alive 0 +WINHTTP_DISABLE_KEEP_ALIVE+)))
+
+            (dolist (header headers)
+              (add-request-headers req
+                                   (format nil "~:(~A~): ~A" (car header) (cdr header))))
+
+            (when (and (equalp (quri:uri-scheme uri) "https")
+                       insecure)
+              (set-ignore-certificates req))
+
+            (when timeout
+              (set-timeouts req :connect timeout :recv timeout))
+
+            (send-request req content)
+
+            (receive-response req)
+
+            (let ((status (query-status-code req))
+                  (response-headers (query-headers* req)))
+              (let* ((bytes (query-data-available req))
+                     (body (make-array bytes :element-type '(unsigned-byte 8))))
+                (read-data req body)
+
+                ;; Redirect
+                (when (and (member status '(301 302 303 307))
+                           (gethash "location" response-headers)
+                           (/= max-redirects 0))
+                  (let ((location-uri (quri:uri (gethash "location" response-headers))))
+                    (let ((method
+                            (if (and (or (null (quri:uri-host location-uri))
+                                         (and (string= (quri:uri-scheme location-uri)
+                                                       (quri:uri-scheme uri))
+                                              (string= (quri:uri-host location-uri)
+                                                       (quri:uri-host uri))
+                                              (eql (quri:uri-port location-uri)
+                                                   (quri:uri-port uri))))
+                                     (or (= status 307)
+                                         (member method '(:get :head) :test #'eq)))
+                                method
+                                :get)))
+                      (return-from request
+                        (apply #'request (quri:merge-uris location-uri uri)
+                               :max-redirects (1- max-redirects)
+                               :method method
+                               args)))))
+
+                (let ((body (if force-binary
+                                body
+                                (decode-body (gethash "content-type" response-headers) body))))
+                  ;; Raise an error when the HTTP response status is 4xx or 5xx.
+                  (when (<= 400 status)
+                    (restart-case
+                        (http-request-failed status
+                                             :body body
+                                             :headers response-headers
+                                             :uri uri
+                                             :method method)
+                      (retry-request ()
+                        :report "Retry the same request."
+                        (apply #'request uri args))
+                      (ignore-and-continue ()
+                        :report "Ignore the error and continue.")))
+
+                  ;; TODO: want-stream support
+                  (values body
+                          status
+                          response-headers
+                          uri))))))))))

--- a/src/backend/winhttp.lisp
+++ b/src/backend/winhttp.lisp
@@ -100,7 +100,9 @@
                    ca-path))
   (let ((uri (quri:uri uri))
         (content-type
-          (find :content-type headers :key #'car :test #'eq)))
+          (find :content-type headers :key #'car :test #'string-equal))
+        (user-agent
+          (find :user-agent headers :key #'car :test #'string-equal)))
     (multiple-value-bind (content detected-content-type) (convert-content content)
       (when (and (null content-type)
                  detected-content-type)
@@ -114,7 +116,7 @@
             (setf headers
                   (append headers
                           `(("Cookie" . ,(write-cookie-header cookies))))))))
-      (with-http (session)
+      (with-http (session (or user-agent *default-user-agent*))
         (with-connect (conn session (quri:uri-host uri) (quri:uri-port uri))
           (with-request (req conn :verb method
                                   :url (format nil "~@[~A~]~@[?~A~]"

--- a/src/backend/winhttp.lisp
+++ b/src/backend/winhttp.lisp
@@ -126,9 +126,12 @@
                                                (quri:uri-path uri)
                                                (quri:uri-query uri))
                                   :https-p (equalp (quri:uri-scheme uri) "https"))
-            (when (quri:uri-userinfo uri)
-              (destructuring-bind (user pass) (split-sequence #\: (quri:uri-userinfo uri))
-                (set-credentials req user pass)))
+            (cond
+              ((quri:uri-userinfo uri)
+               (destructuring-bind (user pass) (split-sequence #\: (quri:uri-userinfo uri))
+                 (set-credentials req user pass)))
+              (basic-auth
+               (set-credentials req (car basic-auth) (cdr basic-auth))))
 
             ;; TODO: SSL arguments
             ;; TODO: proxy support

--- a/src/backend/winhttp.lisp
+++ b/src/backend/winhttp.lisp
@@ -15,6 +15,7 @@
   (:import-from #:fast-io
                 #:fast-output-stream
                 #:finish-output-stream)
+  (:import-from #:babel)
   (:import-from #:flexi-streams)
   (:import-from #:cl-cookie
                 #:cookie-jar-host-cookies
@@ -91,15 +92,15 @@
                             (max-redirects 5)
                             ssl-key-file ssl-cert-file ssl-key-password
                             stream (verbose *verbose*)
-                            force-binary
+                            force-binary force-string
                             want-stream
                             proxy
                             (insecure *not-verify-ssl*)
                             ca-path)
-  (declare (ignore version basic-auth cookie-jar use-connection-pool
+  (declare (ignore version use-connection-pool
                    ssl-key-file ssl-cert-file ssl-key-password
                    stream verbose
-                   want-stream proxy
+                   proxy
                    ca-path))
   (let ((uri (quri:uri uri))
         (content-type
@@ -206,7 +207,10 @@
 
                 (let ((body (if force-binary
                                 body
-                                (decode-body (gethash "content-type" response-headers) body))))
+                                (decode-body (gethash "content-type" response-headers) body
+                                             :default-charset (if force-string
+                                                                  babel:*default-character-encoding*
+                                                                  nil)))))
                   ;; Raise an error when the HTTP response status is 4xx or 5xx.
                   (when (<= 400 status)
                     (restart-case

--- a/src/body.lisp
+++ b/src/body.lisp
@@ -1,0 +1,86 @@
+(defpackage #:dexador.body
+  (:use #:cl)
+  (:import-from #:dexador.encoding
+                #:detect-charset)
+  (:import-from #:dexador.decoding-stream
+                #:make-decoding-stream)
+  (:import-from #:dexador.util
+                #:ascii-string-to-octets
+                #:+crlf+)
+  (:import-from #:babel
+                #:octets-to-string
+                #:character-decoding-error)
+  (:import-from #:babel-encodings
+                #:*suppress-character-coding-errors*)
+  (:import-from :trivial-mimes
+                :mime)
+  (:import-from #:quri
+                #:url-encode)
+  (:export #:decode-body
+           #:write-multipart-content))
+(in-package #:dexador.body)
+
+(defun decode-body (content-type body)
+  (let ((charset (and content-type
+                      (detect-charset content-type body)))
+        (babel-encodings:*suppress-character-coding-errors* t))
+    (if charset
+        (handler-case
+            (if (streamp body)
+                (make-decoding-stream body :encoding charset)
+                (babel:octets-to-string body :encoding charset))
+          (babel:character-decoding-error (e)
+            (warn (format nil "Failed to decode the body to ~S due to the following error (falling back to binary):~%  ~A"
+                          charset
+                          e))
+            (return-from decode-body body)))
+        body)))
+
+(defun content-disposition (key val)
+  (if (pathnamep val)
+      (let* ((filename (file-namestring val))
+             (utf8-filename-p (find-if (lambda (char)
+                                         (< 127 (char-code char)))
+                                       filename)))
+        (format nil "Content-Disposition: form-data; name=\"~A\"; ~:[filename=\"~A\"~;filename*=UTF-8''~A~]~C~C"
+                key
+                utf8-filename-p
+                (if utf8-filename-p
+                    (url-encode filename :encoding :utf-8)
+                    filename)
+                #\Return #\Newline))
+      (format nil "Content-Disposition: form-data; name=\"~A\"~C~C"
+              key
+              #\Return #\Newline)))
+
+(defun write-multipart-content (content boundary stream)
+  (let ((boundary (ascii-string-to-octets boundary)))
+    (labels ((boundary-line (&optional endp)
+               (write-sequence (ascii-string-to-octets "--") stream)
+               (write-sequence boundary stream)
+               (when endp
+                 (write-sequence (ascii-string-to-octets "--") stream))
+               (crlf))
+             (crlf () (write-sequence +crlf+ stream)))
+      (loop for (key . val) in content
+            do (boundary-line)
+               (write-sequence (ascii-string-to-octets (content-disposition key val)) stream)
+               (when (pathnamep val)
+                 (write-sequence
+                  (ascii-string-to-octets
+                   (format nil "Content-Type: ~A~C~C"
+                           (mimes:mime val)
+                           #\Return #\Newline))
+                  stream))
+               (crlf)
+               (typecase val
+                 (pathname (let ((buf (make-array 1024 :element-type '(unsigned-byte 8))))
+                             (with-open-file (in val :element-type '(unsigned-byte 8))
+                               (loop for n of-type fixnum = (read-sequence buf in)
+                                     until (zerop n)
+                                     do (write-sequence buf stream :end n)))))
+                 (string (write-sequence (babel:string-to-octets val) stream))
+                 (otherwise (write-sequence (babel:string-to-octets (princ-to-string val)) stream)))
+               (crlf)
+            finally
+               (boundary-line t)))))

--- a/src/body.lisp
+++ b/src/body.lisp
@@ -25,9 +25,10 @@
            #:decompress-body))
 (in-package #:dexador.body)
 
-(defun decode-body (content-type body)
-  (let ((charset (and content-type
-                      (detect-charset content-type body)))
+(defun decode-body (content-type body &key default-charset)
+  (let ((charset (or (and content-type
+                          (detect-charset content-type body))
+                     default-charset))
         (babel-encodings:*suppress-character-coding-errors* t))
     (if charset
         (handler-case

--- a/src/dexador.lisp
+++ b/src/dexador.lisp
@@ -1,13 +1,11 @@
 (in-package :cl-user)
 (defpackage dexador
   (:nicknames :dex)
-  (:use :cl)
+  (:use :cl
+        #-windows #:dexador.backend.usocket
+        #+windows #:dexador.backend.winhttp)
   (:shadow :get
            :delete)
-  (:import-from :dexador.backend.usocket
-                :request
-                :retry-request
-                :ignore-and-continue)
   (:import-from :dexador.connection-cache
                 :*connection-pool*
                 :*use-connection-pool*

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -90,15 +90,13 @@
 
 (defparameter *header-buffer* nil)
 
-(defun write-first-line (method uri proxy version &optional (buffer *header-buffer*))
+(defun write-first-line (method uri version &optional (buffer *header-buffer*))
   (fast-write-sequence (ascii-string-to-octets (string method)) buffer)
   (fast-write-byte #.(char-code #\Space) buffer)
   (fast-write-sequence (ascii-string-to-octets
-                         (if proxy
-                           (render-uri uri)
-                           (format nil "~A~:[~;~:*?~A~]"
-                                   (or (uri-path uri) "/")
-                                   (uri-query uri))))
+                         (format nil "~A~:[~;~:*?~A~]"
+                                 (or (uri-path uri) "/")
+                                 (uri-query uri)))
                        buffer)
   (fast-write-byte #.(char-code #\Space) buffer)
   (fast-write-sequence (ecase version

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -126,6 +126,9 @@
       (is code 200)
       (is (quri:uri-path uri) "/200"))))
 
+#+windows
+(skip 1 "Content-Disposition tests are skipped")
+#-windows
 (subtest "content-disposition"
   (is (dexador.backend.usocket::content-disposition "upload" #P"data/plain-file.txt")
       (format nil "Content-Disposition: form-data; name=\"upload\"; filename=\"plain-file.txt\"~C~C"

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -226,12 +226,6 @@
                        #\Return #\Newline))
         "string value")))
 
-;; SBCL replaces LF with CRLF when reading from a stream on Windows
-(defun replace-crlf-to-lf (string)
-  (ppcre:regex-replace-all (format nil "~C~C" #\Return #\Newline)
-                           string
-                           (format nil "~C" #\Newline)))
-
 (deftest post-request-tests
   (testing-app "POST request"
       (lambda (env)
@@ -241,7 +235,7 @@
                                   :element-type '(unsigned-byte 8))))
              (read-sequence buf (getf env :raw-body))
              `(200 ()
-                   (,(replace-crlf-to-lf (babel:octets-to-string buf))))))
+                   (,(babel:octets-to-string buf)))))
           (t
            (let ((req (lack.request:make-request env)))
              `(200 ()
@@ -254,7 +248,7 @@
                                                 (streamp (car v)))
                                            (let* ((buf (make-array 1024 :element-type '(unsigned-byte 8)))
                                                   (n (read-sequence buf (car v))))
-                                             (replace-crlf-to-lf (babel:octets-to-string (subseq buf 0 n)))))
+                                             (babel:octets-to-string (subseq buf 0 n))))
                                           ((consp v)
                                            (car v))
                                           (t v)))))))))))

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -226,6 +226,12 @@
                        #\Return #\Newline))
         "string value")))
 
+;; SBCL replaces LF with CRLF when reading from a stream on Windows
+(defun replace-crlf-to-lf (string)
+  (ppcre:regex-replace-all (format nil "~C~C" #\Return #\Newline)
+                           string
+                           (format nil "~C" #\Newline)))
+
 (deftest post-request-tests
   (testing-app "POST request"
       (lambda (env)
@@ -235,7 +241,7 @@
                                   :element-type '(unsigned-byte 8))))
              (read-sequence buf (getf env :raw-body))
              `(200 ()
-                   (,(babel:octets-to-string buf)))))
+                   (,(replace-crlf-to-lf (babel:octets-to-string buf))))))
           (t
            (let ((req (lack.request:make-request env)))
              `(200 ()
@@ -248,7 +254,7 @@
                                                 (streamp (car v)))
                                            (let* ((buf (make-array 1024 :element-type '(unsigned-byte 8)))
                                                   (n (read-sequence buf (car v))))
-                                             (babel:octets-to-string (subseq buf 0 n))))
+                                             (replace-crlf-to-lf (babel:octets-to-string (subseq buf 0 n)))))
                                           ((consp v)
                                            (car v))
                                           (t v)))))))))))

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -49,6 +49,9 @@
         (ok (equal body "/foo"))))))
 
 (deftest proxy-http-tests
+  #+windows
+  (skip "Skipped proxy tests on Windows")
+  #-windows
   (testing-app "proxy (http) case"
       ; proxy behavior is same as direct connection if http
       (lambda (env)

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -359,9 +359,10 @@ body: \"Within a couple weeks of learning Lisp I found programming in any other 
         '(200 (:content-type "text/plain") ("hi")))
     ;; decoding stream
     (let ((body (dex:get (localhost) :want-stream t :keep-alive nil)))
+      #-windows
       (ok (typep body 'dexador.decoding-stream:decoding-stream)
           "body is a decoding stream")
-      (ok (eq (stream-element-type body) 'babel:unicode-char)
+      (ok (subtypep (stream-element-type body) 'babel:unicode-char)
           "body is a character stream")
       (let ((buf (make-string 2)))
         (read-sequence buf body)
@@ -369,7 +370,7 @@ body: \"Within a couple weeks of learning Lisp I found programming in any other 
     ;; binary stream
     (let ((body (dex:get (localhost) :want-stream t :force-binary t :keep-alive nil)))
       (ok (typep body 'stream) "body is a stream")
-      (ok (equal (stream-element-type body) '(unsigned-byte 8))
+      (ok (subtypep (stream-element-type body) '(unsigned-byte 8))
           "body is a octets stream")
       (let ((buf (make-array 2 :element-type '(unsigned-byte 8))))
         (read-sequence buf body)
@@ -384,9 +385,10 @@ body: \"Within a couple weeks of learning Lisp I found programming in any other 
               ("[{\"name\":\"allow-statement-in-has-a\",\"commit\":{\"sha\":\"d58b3c96503786c64eb2dba22980ebb14010bdbf\",\"url\":\"https://api.github.com/repos/fukamachi/datafly/commits/d58b3c96503786c64eb2dba22980ebb14010bdbf\"}},{\"name\":\"fix-has-a\",\"commit\":{\"sha\":\"4bcea61e84402317ab49605918972983a1511e6a\",\"url\":\"https://api.github.com/repos/fukamachi/datafly/commits/4bcea61e84402317ab49605918972983a1511e6a\"}},{\"name\":\"jojo\",\"commit\":{\"sha\":\"d2b753e7fdd0dbeada9721380cf410186a85535b\",\"url\":\"https://api.github.com/repos/fukamachi/datafly/commits/d2b753e7fdd0dbeada9721380cf410186a85535b\"}},{\"name\":\"master\",\"commit\":{\"sha\":\"d2b753e7fdd0dbeada9721380cf410186a85535b\",\"url\":\"https://api.github.com/repos/fukamachi/datafly/commits/d2b753e7fdd0dbeada9721380cf410186a85535b\"}}]")))
     ;; decoding stream
     (let ((body (dex:get (localhost) :want-stream t)))
+      #-windows
       (ok (typep body 'dexador.decoding-stream:decoding-stream)
           "body is a decoding stream")
-      (ok (eq (stream-element-type body) 'babel:unicode-char)
+      (ok (subtypep (stream-element-type body) 'babel:unicode-char)
           "body is a character stream")
       (let ((buf (make-string 1024)))
         (ok (eql (read-sequence buf body) 748))))))

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -259,9 +259,7 @@
                                ("email" . "e.arrows@gmail.com")))
         (declare (ignore headers))
         (ok (eql code 200))
-        (ok (equal body "name: Eitaro
-email: e.arrows@gmail.com
-"))))
+        (ok (equal body (format nil "name: Eitaro~%email: e.arrows@gmail.com~%")))))
     (testing "string content"
       (multiple-value-bind (body code headers)
           (dex:post (localhost "/upload")
@@ -283,17 +281,14 @@ email: e.arrows@gmail.com
                                ("body" . ,(asdf:system-relative-pathname :dexador #P"t/data/quote.txt"))))
         (ok (eql code 200))
         (ok (equal body
-                   "title: Road to Lisp
-body: \"Within a couple weeks of learning Lisp I found programming in any other language unbearably constraining.\" -- Paul Graham, Road to Lisp
-
-"))))
+                   (format nil "title: Road to Lisp~%body: \"Within a couple weeks of learning Lisp I found programming in any other language unbearably constraining.\" -- Paul Graham, Road to Lisp~2%")))))
     (testing "upload"
       (multiple-value-bind (body code)
           (dex:post (localhost "/upload")
                     :content (asdf:system-relative-pathname :dexador #P"t/data/quote.txt"))
         (ok (eql code 200))
-        (ok (equal body "\"Within a couple weeks of learning Lisp I found programming in any other language unbearably constraining.\" -- Paul Graham, Road to Lisp
-"))))))
+        (ok (equal body
+                   (format nil "\"Within a couple weeks of learning Lisp I found programming in any other language unbearably constraining.\" -- Paul Graham, Road to Lisp~%")))))))
 
 (deftest http-request-failed-tests
   (testing-app "HTTP request failed"


### PR DESCRIPTION
Add a backend for WinHTTP. This allows to use Dexador without installing OpenSSL on Windows.

## TODO
- [x] Basic implementation
- [x] Cookie support
- [x] Pass `User-Agent` header to `WinHttpOpen`
- [x] `:want-stream` support
- [x] gzip/deflate decompression
- [x] multipart request
- [x] `:basic-auth` support

## MAYBE
- [ ] `:verbose` logging
- [ ] Proxy support
- [ ] SSL client certificates
  * https://docs.microsoft.com/en-us/windows/desktop/winhttp/ssl-in-winhttp