### PR TITLE
Adding stream-read-byte for compatibility

### DIFF
--- a/src/keep-alive-stream.lisp
+++ b/src/keep-alive-stream.lisp
@@ -34,6 +34,16 @@
       (make-instance 'keep-alive-chunked-stream :stream stream)
       (make-instance 'keep-alive-stream :stream stream :end end)))
 
+(defmethod stream-read-byte ((stream keep-alive-stream))
+  (block nil
+    (when (<= (keep-alive-stream-end stream) 0)
+      (return :eof))
+    (let ((byte (read-byte (keep-alive-stream-stream stream) nil nil)))
+      (decf (keep-alive-stream-end stream) 1)
+      (unless byte 
+        (return :eof))      
+      (return byte))))
+
 (defmethod stream-read-byte ((stream keep-alive-chunked-stream))
   (block nil
     (when (= (slot-value stream 'state) 3)


### PR DESCRIPTION
```lisp
(ql:quickload 'dexador)
(ql:quickload 'opticl)

(opticl:read-image-stream
   (dexador:get "http://httpbin.org/image/jpeg" :want-stream t) "jpeg")
```

Results in error on Linux:
```
The stream
#<DEXADOR.KEEP-ALIVE-STREAM:KEEP-ALIVE-STREAM {10067FC6E3}> has
no suitable method for STREAM-READ-BYTE, and so has fallen
through to this method.  If you think that this is a bug, please
report it to the applicable authority (bugs in SBCL itself
should go to the mailing lists referenced from
<http://www.sbcl.org/>).
   [Condition of type SIMPLE-ERROR]
```
