### PR TITLE
Improve external connection pool support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -239,7 +239,7 @@ All functions take similar arguments.
 - `ssl-key-file`, `ssl-cert-file`, `ssl-key-password`
   - for HTTPS connection
 - `stream`
-  - The stream to write an HTTP request. This is the way to reuse a connection and commonly used with `:keep-alive T`.
+  - The stream to write an HTTP request. This is the way to reuse a connection and commonly used with `:keep-alive T`. If the stream is not `eq` to the fifth return value (see below), the caller is responsible for ensuring the stream is closed.
 - `verbose` (boolean)
   - This option is for debugging. If this is `T`, it dumps the HTTP request headers.
 - `proxy` (string)

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -511,9 +511,11 @@
            (finalize-connection (stream connection-header uri)
              (if (or want-stream
                      (connection-keep-alive-p connection-header))
-                 (push-connection (format nil "~A://~A"
-                                          (uri-scheme uri)
-                                          (uri-authority uri)) stream)
+
+                 (when use-connection-pool
+                   (push-connection (format nil "~A://~A"
+                                            (uri-scheme uri)
+                                            (uri-authority uri)) stream))
                  (when (open-stream-p stream)
                    (close stream)))))
     (let* ((uri (quri:uri uri))


### PR DESCRIPTION
I'm implementing my own connection pool external to Dexador and have found some issues.

ba2eeb5 fixes a problem where the stream is pushed to Dexador's connection pool even if `use-connection-pool` is `nil`, causing Dexador to incorrectly close the stream on the second request using said stream.

004acc9 fixes a problem where redirects to a different server reuse the provided stream. There may be more cases where the stream should be removed from `args`, but this was the one that caught my attention.