### PR TITLE
Make sure stream gets closed also when not reused

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -641,7 +641,12 @@
                                              (go retry)))))
                           ,@body)
                         (restart-case
-                            (progn ,@body)
+                            (handler-bind ((error
+                                             (lambda (e)
+                                               (declare (ignore e))
+                                               (when (open-stream-p stream)
+                                                 (close stream :abort t)))))
+                              ,@body)
                           (retry-request ()
                             :report "Retry the same request."
                             (return-from request


### PR DESCRIPTION
This fixes #84 (Request timeout leaves socket in CLOSE_WAIT state).