### PR TITLE
Use :USE-REEXPORT option of UIOP:DEFINE-PACKAGE instead of CL-REEXPORT

### DIFF
--- a/dexador.asd
+++ b/dexador.asd
@@ -23,13 +23,13 @@
                "trivial-mimes"
                "chipz"
                "cl-base64"
-               "cl-reexport"
                "usocket"
                (:feature :windows "winhttp")
                (:feature :windows "flexi-streams")
                (:feature (:and (:not :windows) (:not :dexador-no-ssl)) "cl+ssl")
                "bordeaux-threads"
-               "alexandria")
+               "alexandria"
+               (:version "uiop" "3.1.1"))
   :components ((:module "src"
                 :components
                 ((:file "dexador" :depends-on ("backend" "error"))

--- a/src/dexador.lisp
+++ b/src/dexador.lisp
@@ -1,5 +1,5 @@
 (in-package :cl-user)
-(defpackage dexador
+(uiop:define-package dexador
   (:nicknames :dex)
   (:use :cl
         #-windows #:dexador.backend.usocket
@@ -38,10 +38,9 @@
 
            ;; Restarts
            :retry-request
-           :ignore-and-continue))
+           :ignore-and-continue)
+  (:use-reexport :dexador.error))
 (in-package :dexador)
-
-(cl-reexport:reexport-from :dexador.error)
 
 (defun get (uri &rest args
             &key version headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout max-redirects


### PR DESCRIPTION
This prevents package variance warnings from SBCL when reloading Dexador.