### PR TITLE
Fixes to connection cache

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -239,11 +239,13 @@ All functions take similar arguments.
 - `ssl-key-file`, `ssl-cert-file`, `ssl-key-password`
   - for HTTPS connection
 - `stream`
-  - The stream to write an HTTP request. This is the way to reuse a connection and commonly used with `:keep-alive T`.
+  - The stream to write an HTTP request. This is a way to reuse a connection and commonly used with `:keep-alive T`.  This allows the caller to do connection pooling, etc.  It is easier to just use `:use-connection-pool t` and let the dexador internals take care of this for you (only supported for usocket backends).
 - `verbose` (boolean)
   - This option is for debugging. If this is `T`, it dumps the HTTP request headers.
 - `proxy` (string)
   - for use proxy.
+- `use-connection-pool` (boolean)
+  - When combined with `:keep-alive t`, will internally cache the socket connection to web servers to avoid having to open new ones.  This is compatible with `:want-stream t` (when you close the returned stream or it is garbage collected the connection will be returned to the pool).  If you pass in a stream with `:stream` then the connection pool is not used (unless there is a redirect to a new web server).  This is not supported when using the WINHTTP backend.
 
 ### \[Function\] request
 
@@ -269,7 +271,7 @@ The `response-headers` is a hash table which represents HTTP response headers. N
 
 The `uri` is a [QURI](https://github.com/fukamachi/quri) object which represents the last URI Dexador requested.
 
-The `stream` is a usocket stream to communicate with the HTTP server if the connection is still alive and can be reused. This value may be `NIL` if `:keep-alive` is `NIL` or the server closed the connection with `Connection: close` header.
+The `stream` is a usocket stream to communicate with the HTTP server if the connection is still alive and can be reused. This value may be `NIL` if `:keep-alive` is `NIL` or the server closed the connection with `Connection: close` header or you are using `:use-connection-pool t` which handles re-using the connections for you.
 
 This function signals `http-request-failed` when the HTTP status code is 4xx or 5xx.
 

--- a/dexador.asd
+++ b/dexador.asd
@@ -17,6 +17,7 @@
                "fast-io"
                "babel"
                "trivial-gray-streams"
+               "trivial-garbage"
                "chunga"
                "cl-ppcre"
                "cl-cookie"

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -222,16 +222,16 @@
            d))
     (boundary-line)))
 
-(defun convert-body (body content-encoding content-type content-length chunkedp force-binary force-string keep-alive-p)
+(defun convert-body (body content-encoding content-type content-length chunkedp force-binary force-string keep-alive-p on-close)
   (when (and (streamp body)
              keep-alive-p)
     (cond
       (chunkedp
        (setf body
-             (make-keep-alive-stream body :chunked t)))
+             (make-keep-alive-stream body :chunked t :on-close-or-eof on-close)))
       (content-length
        (setf body
-             (make-keep-alive-stream body :end content-length)))))
+             (make-keep-alive-stream body :end content-length :on-close-or-eof on-close)))))
   (let ((body (decompress-body content-encoding
                                (if (and (streamp body)
                                         chunkedp)
@@ -420,6 +420,37 @@
           (t
            (fail 'dexador.error:socks5-proxy-request-failed :reason "Unknown address")))))))
 
+(defun make-ssl-stream (stream ca-path ssl-key-file ssl-cert-file ssl-key-password hostname insecure)
+  #+(or windows dexador-no-ssl)
+  (error "SSL not supported. Remove :dexador-no-ssl from *features* to enable SSL.")
+  #-(or windows dexador-no-ssl)
+  (cl+ssl:ensure-initialized)
+  (let ((ctx (cl+ssl:make-context :verify-mode
+                                  (if insecure
+                                      cl+ssl:+ssl-verify-none+
+                                      cl+ssl:+ssl-verify-peer+)
+                                  :verify-location
+                                  (cond
+                                    (ca-path (uiop:native-namestring ca-path))
+                                    ((probe-file *ca-bundle*) *ca-bundle*)
+                                    ;; In executable environment, perhaps *ca-bundle* doesn't exist.
+                                    (t :default))))
+        (ssl-cert-pem-p (and ssl-cert-file
+                             (ends-with-subseq ".pem" ssl-cert-file))))
+    (cl+ssl:with-global-context (ctx :auto-free-p t)
+      (when ssl-cert-pem-p
+        (cl+ssl:use-certificate-chain-file ssl-cert-file))
+      (cl+ssl:make-ssl-client-stream stream
+                                     :hostname hostname
+                                     :verify (not insecure)
+                                     :key ssl-key-file
+                                     :certificate (and (not ssl-cert-pem-p)
+                                                       ssl-cert-file)
+                                     :password ssl-key-password))))
+
+(defstruct usocket-wrapped-stream
+  stream)
+
 (defun-careful request (uri &rest args
                             &key (method :get) (version 1.1)
                             content headers
@@ -437,7 +468,8 @@
                             (insecure *not-verify-ssl*)
                             ca-path
                             &aux
-                            (proxy-uri (and proxy (quri:uri proxy))))
+                            (proxy-uri (and proxy (quri:uri proxy)))
+                            (user-supplied-stream (if (usocket-wrapped-stream-p stream) (usocket-wrapped-stream-stream stream) stream)))
   (declare (ignorable ssl-key-file ssl-cert-file ssl-key-password
                       connect-timeout ca-path)
            (type real version)
@@ -458,35 +490,9 @@
                    (when (socks5-proxy-p proxy-uri)
                      (ensure-socks5-connected stream stream uri method))
                    (if (string= scheme "https")
-                       #+(or windows dexador-no-ssl)
-                       (error "SSL not supported. Remove :dexador-no-ssl from *features* to enable SSL.")
-                       #-(or windows dexador-no-ssl)
-                       (progn
-                         (cl+ssl:ensure-initialized)
-                         (let ((ctx (cl+ssl:make-context :verify-mode
-                                                         (if insecure
-                                                             cl+ssl:+ssl-verify-none+
-                                                             cl+ssl:+ssl-verify-peer+)
-                                                         :verify-location
-                                                         (cond
-                                                           (ca-path (uiop:native-namestring ca-path))
-                                                           ((probe-file *ca-bundle*) *ca-bundle*)
-                                                           ;; In executable environment, perhaps *ca-bundle* doesn't exist.
-                                                           (t :default))))
-                               (ssl-cert-pem-p (and ssl-cert-file
-                                                    (ends-with-subseq ".pem" ssl-cert-file))))
-                           (cl+ssl:with-global-context (ctx :auto-free-p t)
-                             (when ssl-cert-pem-p
-                               (cl+ssl:use-certificate-chain-file ssl-cert-file))
-                             (cl+ssl:make-ssl-client-stream (if (http-proxy-p proxy-uri)
-                                                                (make-connect-stream uri version stream (make-proxy-authorization con-uri))
-                                                                stream)
-                                                            :hostname (uri-host uri)
-                                                            :verify (not insecure)
-                                                            :key ssl-key-file
-                                                            :certificate (and (not ssl-cert-pem-p)
-                                                                              ssl-cert-file)
-                                                            :password ssl-key-password))))
+                       (make-ssl-stream (if (http-proxy-p proxy-uri)
+                                               (make-connect-stream uri version stream (make-proxy-authorization con-uri))
+                                               stream) ca-path ssl-key-file ssl-cert-file ssl-key-password (uri-host uri) insecure)
                        stream))
                (retry-request ()
                  :report "Retry the same request."
@@ -509,13 +515,18 @@
                            (equalp connection-header "keep-alive"))
                       (not (equalp connection-header "close")))))
            (finalize-connection (stream connection-header uri)
-             (if (or want-stream
-                     (connection-keep-alive-p connection-header))
-                 (push-connection (format nil "~A://~A"
-                                          (uri-scheme uri)
-                                          (uri-authority uri)) stream)
-                 (when (open-stream-p stream)
-                   (close stream)))))
+             "If KEEP-ALIVE is in the connection-header and the user is not requesting a stream,
+              we will push the connection to our connection pool if allowed, otherwise we return
+              the stream back to the user who must close it."
+             (unless want-stream
+               (cond
+                 ((and (connection-keep-alive-p connection-header) (not user-supplied-stream) use-connection-pool)
+                  (push-connection (format nil "~A://~A"
+                                           (uri-scheme uri)
+                                           (uri-authority uri)) stream #'close))
+                 ((not keep-alive)
+                  (when (open-stream-p stream)
+                    (close stream)))))))
     (let* ((uri (quri:uri uri))
            (proxy (when (http-proxy-p proxy-uri) proxy))
            (content-type
@@ -531,7 +542,7 @@
            (content (if form-urlencoded-p
                         (quri:url-encode-params content)
                         content))
-           (stream (or stream
+           (stream (or user-supplied-stream
                        (and use-connection-pool
                             (steal-connection (format nil "~A://~A"
                                                       (uri-scheme uri)
@@ -631,19 +642,20 @@
                    `(if reusing-stream-p
                         (handler-bind ((error
                                          (lambda (e)
-                                           (declare (ignore e))
+                                           (declare (ignorable e))
                                            (when (open-stream-p stream)
                                              (close stream :abort t))
                                            (when reusing-stream-p
                                              (setf use-connection-pool nil
                                                    reusing-stream-p nil
+                                                   user-supplied-stream nil
                                                    stream (make-new-connection uri))
                                              (go retry)))))
                           ,@body)
                         (restart-case
                             (handler-bind ((error
                                              (lambda (e)
-                                               (declare (ignore e))
+                                               (declare (ignorable e))
                                                (when (open-stream-p stream)
                                                  (close stream :abort t)))))
                               ,@body)
@@ -704,6 +716,7 @@
                                           :method method)))
                  (setf use-connection-pool nil
                        reusing-stream-p nil
+                       user-supplied-stream nil
                        stream (make-new-connection uri))
                  (go retry))
                (when verbose
@@ -743,7 +756,7 @@
                                           (uri-port uri))))
                             (or (= status 307)
                                 (member method '(:get :head) :test #'eq)))
-                       (progn
+                       (progn ;; redirection to the same host
                          (setq uri (merge-uris location-uri uri))
                          (setq first-line-data
                                (with-fast-output (buffer)
@@ -754,15 +767,16 @@
                          (decf max-redirects)
                          (if (equalp (gethash "connection" response-headers) "close")
                              (progn
-                               (finalize-connection stream (gethash "connection" response-headers) uri)
+                               (finalize-connection stream (gethash "connection" response-headers) uri) ;; maybe return the old connection to the pool
                                (setq use-connection-pool nil
                                      reusing-stream-p nil
+                                     user-supplied-stream nil
                                      stream (make-new-connection uri)))
                              (setq reusing-stream-p t))
                          (go retry))
-                       (progn
+                       (progn ;; this is a redirection to a different host
                          (setf location-uri (quri:merge-uris location-uri uri))
-                         (finalize-connection stream (gethash "connection" response-headers) uri)
+                         (finalize-connection stream (gethash "connection" response-headers) uri) ;; maybe return the original stream to the pool
                          (setf (getf args :headers)
                                (nconc `((:host . ,(uri-host location-uri))) headers))
                          (setf (getf args :max-redirects)
@@ -771,18 +785,31 @@
                          (unless (or (= status 307)
                                      (member method '(:get :head) :test #'eq))
                            (setf (getf args :method) :get))
-                         (return-from request
+                         (return-from request ;; we do not return the stream to the pool, as desired.
                            (apply #'request location-uri args))))))
                (unwind-protect
-                    (let ((body (convert-body body
+                    (let* ((keep-connection-alive (connection-keep-alive-p
+                                                   (gethash "connection" response-headers)))
+                           (body (convert-body body
                                               (gethash "content-encoding" response-headers)
                                               (gethash "content-type" response-headers)
                                               content-length
                                               transfer-encoding-p
                                               force-binary
                                               force-string
-                                              (connection-keep-alive-p
-                                               (gethash "connection" response-headers)))))
+                                              keep-connection-alive
+                                              (if (and use-connection-pool keep-connection-alive (not user-supplied-stream) (streamp body))
+                                                  (lambda (underlying-stream abort)
+                                                    (declare (ignore abort))
+                                                    (when (open-stream-p underlying-stream)
+                                                      ;; read any left overs the user may have not read (in case of errors on user side?)
+                                                      (loop while (ignore-errors (listen underlying-stream)) ;; ssl streams may close
+                                                            do (read-byte underlying-stream nil nil))
+                                                      (when (open-stream-p underlying-stream)
+                                                        (push-connection (format nil "~A://~A"
+                                                                                 (uri-scheme uri)
+                                                                                 (uri-authority uri)) underlying-stream #'close))))
+                                                  #'dexador.keep-alive-stream:keep-alive-stream-close-underlying-stream))))
                       ;; Raise an error when the HTTP response status code is 4xx or 50x.
                       (when (<= 400 status)
                         (with-restarts
@@ -791,12 +818,20 @@
                                                :headers response-headers
                                                :uri uri
                                                :method method)))
+                      ;; Have to be a little careful with the stream we return -- the user may
+                      ;; be not aware that keep-alive t without use-connection-pool can leak
+                      ;; sockets, so we wrap the returned last value so when it is garbage
+                      ;; collected, it closes the underlying socket stream.
                       (return-from request
                         (values body
                                 status
                                 response-headers
                                 uri
                                 (when (and keep-alive
-                                           (not (equalp (gethash "connection" response-headers) "close")))
-                                  stream))))
+                                           (not (equalp (gethash "connection" response-headers) "close"))
+                                           (or (not use-connection-pool) user-supplied-stream))
+                                  (or user-supplied-stream
+                                      (let ((wrapped-stream (make-usocket-wrapped-stream :stream stream)))
+                                        (trivial-garbage:finalize wrapped-stream (lambda () (close stream)))
+                                        wrapped-stream))))))
                  (finalize-connection stream (gethash "connection" response-headers) uri)))))))))

--- a/src/body.lisp
+++ b/src/body.lisp
@@ -25,7 +25,7 @@
            #:decompress-body))
 (in-package #:dexador.body)
 
-(defun decode-body (content-type body &key default-charset)
+(defun decode-body (content-type body &key default-charset on-close)
   (let ((charset (or (and content-type
                           (detect-charset content-type body))
                      default-charset))
@@ -33,7 +33,7 @@
     (if charset
         (handler-case
             (if (streamp body)
-                (make-decoding-stream body :encoding charset)
+                (make-decoding-stream body :encoding charset :on-close on-close)
                 (babel:octets-to-string body :encoding charset))
           (babel:character-decoding-error (e)
             (warn (format nil "Failed to decode the body to ~S due to the following error (falling back to binary):~%  ~A"

--- a/src/connection-cache.lisp
+++ b/src/connection-cache.lisp
@@ -2,7 +2,6 @@
 (defpackage dexador.connection-cache
   (:use :cl)
   (:import-from :bordeaux-threads
-                :current-thread
                 :make-lock
                 :with-lock-held)
   (:export :*connection-pool*
@@ -13,65 +12,131 @@
            :clear-connection-pool))
 (in-package :dexador.connection-cache)
 
-(defparameter *connection-pool* nil)
-
-(defvar *threads-connection-pool* nil)
-(defvar *threads-connection-pool-lock*
-  #+thread-support (bt:make-lock "threads connection pool lock"))
-
 (defvar *use-connection-pool* t)
 
-(defun make-connection-pool ()
-  (make-hash-table :test 'equal))
+(defstruct lru-pool-elt
+  (prev nil :type (or null lru-pool-elt))
+  (next nil :type (or null lru-pool-elt))
+  (elt nil :type t)
+  (key nil :type t)
+  (eviction-callback nil :type (or null function)))
 
-#+thread-support
-(defun make-threads-connection-pool ()
-  (let ((pool (make-hash-table :test 'eq)))
-    (setf (gethash (bt:current-thread) pool)
-          (make-connection-pool))
-    pool))
-#-thread-support
-(defun make-threads-connection-pool ()
-  (make-connection-pool))
+;; An LRU-POOL can have multiple entries for the same key
+(defstruct lru-pool
+  (lock #+thread-support (bt:make-lock "connection pool lock")
+        #-thread-support nil)
+  (hash-table nil :type (or null hash-table)) ;; hash table entries are lists of elements
+  (head nil :type (or null lru-pool-elt)) ;; most recently used is here and it's a doubly-linked-list
+  (tail nil :type (or null lru-pool-elt)) ;; least recently used is here
+  (num-elts 0 :type fixnum)
+  (max-elts 8 :type fixnum))
 
-(defun initialize-threads-connection-pool ()
-  (setf *threads-connection-pool* (make-threads-connection-pool)))
+(defun make-connection-pool (&optional (max-active-connections 8))
+  (make-lru-pool :hash-table (make-hash-table :test 'equal) :max-elts max-active-connections))
 
-#+thread-support
-(defun get-connection-pool ()
-  (or *connection-pool*
-      (gethash (bt:current-thread) *threads-connection-pool*)
-      (bt:with-lock-held (*threads-connection-pool-lock*)
-        (setf (gethash (bt:current-thread) *threads-connection-pool*)
-              (make-connection-pool)))))
-#-thread-support
-(defun get-connection-pool ()
-  (or *connection-pool*
-      *threads-connection-pool*))
+(defparameter *connection-pool* (make-connection-pool))
+
+(defun get-from-lru-pool (lru-pool key)
+  "Must be called with lru-cache-lock held.  Removes element from pool."
+  (let* ((hash-table (lru-pool-hash-table lru-pool))
+         (possible-elts (gethash key (lru-pool-hash-table lru-pool))))
+    (when possible-elts
+      (let ((remaining-elts (cdr possible-elts)))
+        (if remaining-elts
+            (setf (gethash key hash-table) remaining-elts)
+            (remhash key hash-table)))
+      (let ((elt (car possible-elts)))
+        (let ((prev (lru-pool-elt-prev elt))
+              (next (lru-pool-elt-next elt)))
+          (if prev
+              (setf (lru-pool-elt-next prev) next)
+              (setf (lru-pool-head lru-pool) next))
+          (if next
+              (setf (lru-pool-elt-prev next) prev)
+              (setf (lru-pool-tail lru-pool) prev)))
+        (decf (lru-pool-num-elts lru-pool))
+        (lru-pool-elt-elt elt)))))
+
+(defun evict-tail (lru-pool)
+  "Must be called with lru-pool-lock held.  Returns the eviction callback which you
+   must call (after releasing the lru-pool-lock)."
+  ;; slightly different from get-from-lru-pool because we want to get rid of the
+  ;; actual oldest element (one could in principle call get-from-lru-pool on
+  ;; (lru-pool-elt-key (lru-pool-tail lru-pool)) if you didn't care
+  (let* ((tail (lru-pool-tail lru-pool)))
+    (when tail
+      (let ((prev (lru-pool-elt-prev tail)))
+        (if prev
+            (setf (lru-pool-elt-next prev) nil)
+            (setf (lru-pool-head lru-pool) nil))
+        (setf (lru-pool-tail lru-pool) prev)
+        (let* ((hash-table (lru-pool-hash-table lru-pool))
+               (key (lru-pool-elt-key tail))
+               (remaining (delete tail (gethash key hash-table))))
+          (if remaining
+              (setf (gethash key hash-table) remaining)
+              (remhash key hash-table))))
+      (decf (lru-pool-num-elts lru-pool))
+      (values (lru-pool-elt-eviction-callback tail) t))))
+
+(defun add-to-lru-pool (lru-pool key elt eviction-callback)
+  "Must be called with lru-pool-lock held.  Adds elt as most recently used.
+   If an element was evicted, returns (values eviction-callback t) otherwise nil"
+  (declare (type lru-pool lru-pool))
+  (let* ((old-head (lru-pool-head lru-pool))
+         (lru-pool-elt (make-lru-pool-elt :prev nil :next old-head :elt elt :key key :eviction-callback eviction-callback))
+         (hash-table (lru-pool-hash-table lru-pool)))
+    (setf (lru-pool-head lru-pool) lru-pool-elt)
+    (push lru-pool-elt (gethash key hash-table))
+    (when old-head
+      (setf (lru-pool-elt-prev old-head) lru-pool-elt))
+    (unless (lru-pool-tail lru-pool)
+      (setf (lru-pool-tail lru-pool) lru-pool-elt))
+    (when (> (incf (lru-pool-num-elts lru-pool)) (lru-pool-max-elts lru-pool))
+      (evict-tail lru-pool))))
+
+(defmethod print-object ((obj lru-pool-elt) str) ;; avoid printing loops
+  (format str "<LRU-POOL-ELT ~A NEXT ~A>" (lru-pool-elt-key obj) (lru-pool-elt-next obj)))
+
+(defmethod print-object ((obj lru-pool) str) ;; avoid printing loops
+  (let (objs)
+    (loop with lru-pool-elt = (lru-pool-head obj)
+          while lru-pool-elt
+          do (push (cons (lru-pool-elt-key lru-pool-elt) (lru-pool-elt-elt lru-pool-elt)) objs)
+          do (setf lru-pool-elt (lru-pool-elt-next lru-pool-elt)))
+    (format str "<LRU-POOL ~A/~A elts:~%~{ ~A~^~%~}>" (lru-pool-num-elts obj) (lru-pool-max-elts obj) objs)))
+
+(defmacro with-lock (lock &body body)
+  (declare (ignorable lock))
+  #+thread-support `(bt:with-lock-held (,lock)
+                      ,@body)
+  #-thread-support `(progn ,@body))
+
+(defun push-connection (host-port socket &optional eviction-callback)
+  "Add socket back to connection pool"
+  (when *use-connection-pool*
+    (let ((pool *connection-pool*))
+      (let ((evicted-elt-eviction-callback
+              (with-lock (lru-pool-lock pool)
+                (add-to-lru-pool pool host-port socket eviction-callback))))
+        (and evicted-elt-eviction-callback (funcall evicted-elt-eviction-callback))
+        (values)))))
 
 (defun steal-connection (host-port)
   (when *use-connection-pool*
-    (let* ((*connection-pool* (get-connection-pool))
-           (conn (gethash host-port *connection-pool*)))
-      (when conn
-        (remhash host-port *connection-pool*)
-        conn))))
-
-(defun push-connection (host-port socket)
-  (when *use-connection-pool*
-    (let* ((*connection-pool* (get-connection-pool))
-           (old-conn (gethash host-port *connection-pool*)))
-      (when old-conn
-        (ignore-errors (close old-conn)))
-      (setf (gethash host-port *connection-pool*)
-            socket))))
+    (let ((pool *connection-pool*))
+      (with-lock (lru-pool-lock pool)
+        (get-from-lru-pool pool host-port)))))
 
 (defun clear-connection-pool ()
-  (let ((pool (get-connection-pool)))
-    (maphash (lambda (host-port conn)
-               (ignore-errors (close conn))
-               (remhash host-port pool))
-             pool)
-    t))
+  (when *use-connection-pool*
+    (let ((pool *connection-pool*)
+          eviction-callback element-was-evicted)
+      (loop for count from 0
+            do (setf (values eviction-callback element-was-evicted) (evict-tail pool))
+            do (when eviction-callback (funcall eviction-callback))
+            do (format t "Evicted ~A elts so far~%" count)
+            while element-was-evicted))))
 
-(initialize-threads-connection-pool)
+            
+            

--- a/src/connection-cache.lisp
+++ b/src/connection-cache.lisp
@@ -40,11 +40,9 @@
 
 (defun make-new-connection-pool (&optional (max-active-connections *max-active-connections*))
   (clear-connection-pool)
-  (setf *connection-pool* (make-new-connection-pool)))
+  (setf *connection-pool* (make-connection-pool max-active-connections)))
 
 (defvar *connection-pool* nil)
-
-(make-new-connection-pool)
 
 (defun get-from-lru-pool (lru-pool key)
   "Takes an element from the LRU-POOL matching KEY.  Must be called with LRU-POOL-LOCK held.
@@ -142,7 +140,7 @@
     (let ((pool *connection-pool*))
       (multiple-value-bind (evicted-elt eviction-callback)
           (with-lock (lru-pool-lock pool)
-            (add-to-lru-pool pool host-port socket eviction-callback))
+            (add-to-lru-pool pool host-port stream eviction-callback))
         (and eviction-callback (funcall eviction-callback evicted-elt))
         (values)))))
 
@@ -164,5 +162,4 @@
               do (when eviction-callback (funcall eviction-callback evicted-element))
               while element-was-evicted)))))
 
-            
-            
+(make-new-connection-pool)

--- a/src/decoding-stream.lisp
+++ b/src/decoding-stream.lisp
@@ -48,7 +48,8 @@ Similar to flexi-input-stream, except this uses Babel for decoding."))
               :accessor decoding-stream-last-char)
    (last-char-size :type fixnum
                    :initform 0
-                   :accessor decoding-stream-last-char-size)))
+                   :accessor decoding-stream-last-char-size)
+   (on-close :type (or null function) :initform nil :initarg :on-close)))
 
 (defmethod initialize-instance :after ((stream decoding-stream) &rest initargs)
   (declare (ignore initargs))
@@ -56,10 +57,12 @@ Similar to flexi-input-stream, except this uses Babel for decoding."))
     (when (keywordp encoding)
       (setf encoding (get-character-encoding encoding)))))
 
-(defun make-decoding-stream (stream &key (encoding babel-encodings:*default-character-encoding*))
+(defun make-decoding-stream (stream &key (encoding babel-encodings:*default-character-encoding*)
+                                      (on-close))
   (let ((decoding-stream (make-instance 'decoding-stream
                                         :stream stream
-                                        :encoding encoding)))
+                                        :encoding encoding
+                                        :on-close on-close)))
     (fill-buffer decoding-stream)
     decoding-stream))
 
@@ -153,6 +156,7 @@ Similar to flexi-input-stream, except this uses Babel for decoding."))
   'unicode-char)
 
 (defmethod close ((stream decoding-stream) &key abort)
+  ;; TODO: modify me to return the connection to the connection pool
   (with-slots (stream) stream
     (when (open-stream-p stream)
       (close stream :abort abort))))

--- a/src/dexador.lisp
+++ b/src/dexador.lisp
@@ -46,6 +46,28 @@
             &key version headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout max-redirects
               force-binary force-string want-stream
               ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path)
+  "Make a GET request to URI and return
+    (values body-or-stream status response-headers uri &optional opaque-socket-stream)
+
+  You may pass a real stream in as STREAM if you want us to communicate with the server via it --
+  though if any errors occur, we will open a new connection to the server.  If you have a previous
+  OPAQUE-SOCKET-STREAM you can pass that in as STREAM as well and we will re-use that connection.
+
+  OPAQUE-SOCKET-STREAM is not returned if USE-CONNECTION-POOL is T, instead we keep track of it and
+  re-use it when needed.
+
+  If WANT-STREAM is T, then a STREAM is returned as the first value.  You may read this as needed to
+  get the body of the response.  If KEEP-ALIVE and USE-CONNECTION-POOL are T, then the stream will be
+  returned to the connection pool when you have read all the data or closed the stream.
+
+  If KEEP-ALIVE is T and USE-CONNECTION-POOL is NIL, then the fifth value returned is a stream which
+  you can then pass in again using the STREAM option to re-use the active connection.  If you ignore
+  the stream, it will get closed during garbage collection.
+
+  If KEEP-ALIVE is T and USE-CONNECTION-POOL is T, then there is no fifth
+  value (OPAQUE-SOCKET-STREAM) returned, but the active connection to the host/port may be reused in
+  subsequent calls.  This removes the need for the caller to keep track of the active socket-stream
+  for subsequent calls."
   (declare (ignore version headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout max-redirects force-binary force-string want-stream ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path))
   (apply #'request uri :method :get args))
 

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -378,6 +378,7 @@
     ;; binary stream
     (let ((body (dex:get (localhost) :want-stream t :force-binary t :keep-alive nil)))
       (ok (typep body 'stream) "body is a stream")
+      (ok (open-stream-p body) "body is open")
       (ok (subtypep (stream-element-type body) '(unsigned-byte 8))
           "body is a octets stream")
       (let ((buf (make-array 2 :element-type '(unsigned-byte 8))))
@@ -511,7 +512,7 @@
           (result2 (dexador.connection-cache:steal-connection "host1")))
       (ok (and (stringp result1) (stringp result2) (not (string= result1 result2)))))
     ;; make sure hash table stays clean
-    (ok (zerop (hash-table-size (dexador.connection-cache::lru-pool-hash-table dexador.connection-cache::*connection-pool*))))
+    (ok (zerop (hash-table-count (dexador.connection-cache::lru-pool-hash-table dexador.connection-cache::*connection-pool*))))
     ;; make sure maximum connections is obeyed and least recently used element is evicted
     (dexador.connection-cache:push-connection "host1" "host1-socket1")
     (dexador.connection-cache:push-connection "host2" "host2-socket")
@@ -522,14 +523,14 @@
     (ok (null (dexador.connection-cache:steal-connection "host2")))
     ;; Make sure clear-connection-pool works and callbacks are called
     (let ((called nil))
-      (dexador.connection-cache:push-connection "host1" "host1-socket1" (lambda () (setf called t)))
+      (dexador.connection-cache:push-connection "host1" "host1-socket1" (lambda (s) (declare (ignore s)) (setf called t)))
       (dexador.connection-cache:clear-connection-pool)
       (ok called)
       (setf called nil)
-      (dexador.connection-cache:push-connection "host1" "host1-socket" (lambda () (setf called "host1")))
-      (dexador.connection-cache:push-connection "host2" "host2-socket" (lambda () (setf called "host2")))
-      (dexador.connection-cache:push-connection "host3" "host3-socket" (lambda () (setf called "host3")))
+      (dexador.connection-cache:push-connection "host1" "host1-socket" (lambda (s) (declare (ignore s))  (setf called "host1")))
+      (dexador.connection-cache:push-connection "host2" "host2-socket" (lambda (s) (declare (ignore s)) (setf called "host2")))
+      (dexador.connection-cache:push-connection "host3" "host3-socket" (lambda (s) (declare (ignore s)) (setf called "host3")))
       (ok (string= called "host1"))
-      (dexador.connection-cache:push-connection "host4" "host4-socket" (lambda () (setf called "host4")))
+      (dexador.connection-cache:push-connection "host4" "host4-socket" (lambda (s) (declare (ignore s)) (setf called "host4")))
       (ok (string= called "host2")))))
   


### PR DESCRIPTION
This should prevent leaking of file descriptors and other strange behaviors.  There is a slight user facing change, nth-value 4 of request calls is nil if use-connection-pool is t and the actual value returned is not a socket-stream, but can be passed in as :stream in further calls (and can any actual stream for that matter).  There is an added dependency on trivial-garbage to handle finalizing the socket when user uses :use-connection-pool nil and :keep-alive t and does not close the returned socket (since keep-alive defaults to t this makes sense to me).  To avoid adding more dependencies the double ended queue in the LRU connection pool is bespoke.  I would be happy to use a library that provides a deque instead too.

I added some comments and some tests too and did a slight refactor in make-new-connection to make it a little clearer.

This has *not* been tested heavily, so consider this pull request as the beginning of a discussion.

See [Issue 29](https://github.com/fukamachi/dexador/issues/106) for more details.