### PR TITLE
Fix not to refer CL+SSL on Windows

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Install Rove
         shell: bash
         run: /c/roswell/bin/ros install fukamachi/rove
+      - name: Load Dexador
+        shell: bash
+        run: |
+          /c/roswell/bin/ros -e '(handler-bind ((error (lambda (e) (uiop:print-condition-backtrace e) (uiop:quit -1)))) (ql:quickload :dexador))'
       - name: Run tests
         shell: bash
         run: |

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -424,29 +424,30 @@
   #+(or windows dexador-no-ssl)
   (error "SSL not supported. Remove :dexador-no-ssl from *features* to enable SSL.")
   #-(or windows dexador-no-ssl)
-  (cl+ssl:ensure-initialized)
-  (let ((ctx (cl+ssl:make-context :verify-mode
-                                  (if insecure
-                                      cl+ssl:+ssl-verify-none+
-                                      cl+ssl:+ssl-verify-peer+)
-                                  :verify-location
-                                  (cond
-                                    (ca-path (uiop:native-namestring ca-path))
-                                    ((probe-file *ca-bundle*) *ca-bundle*)
-                                    ;; In executable environment, perhaps *ca-bundle* doesn't exist.
-                                    (t :default))))
-        (ssl-cert-pem-p (and ssl-cert-file
-                             (ends-with-subseq ".pem" ssl-cert-file))))
-    (cl+ssl:with-global-context (ctx :auto-free-p t)
-      (when ssl-cert-pem-p
-        (cl+ssl:use-certificate-chain-file ssl-cert-file))
-      (cl+ssl:make-ssl-client-stream stream
-                                     :hostname hostname
-                                     :verify (not insecure)
-                                     :key ssl-key-file
-                                     :certificate (and (not ssl-cert-pem-p)
-                                                       ssl-cert-file)
-                                     :password ssl-key-password))))
+  (progn
+    (cl+ssl:ensure-initialized)
+    (let ((ctx (cl+ssl:make-context :verify-mode
+                                    (if insecure
+                                        cl+ssl:+ssl-verify-none+
+                                        cl+ssl:+ssl-verify-peer+)
+                                    :verify-location
+                                    (cond
+                                      (ca-path (uiop:native-namestring ca-path))
+                                      ((probe-file *ca-bundle*) *ca-bundle*)
+                                      ;; In executable environment, perhaps *ca-bundle* doesn't exist.
+                                      (t :default))))
+          (ssl-cert-pem-p (and ssl-cert-file
+                               (ends-with-subseq ".pem" ssl-cert-file))))
+      (cl+ssl:with-global-context (ctx :auto-free-p t)
+        (when ssl-cert-pem-p
+          (cl+ssl:use-certificate-chain-file ssl-cert-file))
+        (cl+ssl:make-ssl-client-stream stream
+                                       :hostname hostname
+                                       :verify (not insecure)
+                                       :key ssl-key-file
+                                       :certificate (and (not ssl-cert-pem-p)
+                                                         ssl-cert-file)
+                                       :password ssl-key-password)))))
 
 (defstruct usocket-wrapped-stream
   stream)


### PR DESCRIPTION
It raises the following error when loading Dexador.

```
 ; caught ERROR:
;   READ error during COMPILE-FILE:
;   
;     Package CL+SSL does not exist.
;   
;       Line: 428, Column: 33, File-Position: 17146
;   
;       Stream: #<SB-INT:FORM-TRACKING-STREAM for "file D:\\a\\dexador\\dexador\\src\\backend\\usocket.lisp" {100CB071F3}>
```

ref https://github.com/fukamachi/dexador/runs/4915953226?check_suite_focus=true