### PR TITLE
Fix leaking of fds on 4xx and 5xx and cleanup retry handling

### DIFF
--- a/src/connection-cache.lisp
+++ b/src/connection-cache.lisp
@@ -158,7 +158,9 @@
           evicted-element eviction-callback element-was-evicted)
       (when pool
         (loop for count from 0
-              do (setf (values evicted-element eviction-callback element-was-evicted) (evict-tail pool))
+              do (setf (values evicted-element eviction-callback element-was-evicted)
+                       (with-lock (lru-pool-lock pool)
+                         (evict-tail pool)))
               do (when eviction-callback (funcall eviction-callback evicted-element))
               while element-was-evicted)))))
 


### PR DESCRIPTION
This was caused fundamentally by the many places where we restart a request.  I simplified this so there is a common path that closes any open streams.

I also fixed a minor bug in clear-connection-cache which made it thread-unsafe (so if you called it while dexador was busy using it, it may have leaked fds or corrupted the cache state).

I think we could add, at least on linux / sbcl, a test that looks for fd leakage directly.

I think this addresses #120