### PR TITLE
Fix chunked keep-alive streams

### DIFF
--- a/src/connection-cache.lisp
+++ b/src/connection-cache.lisp
@@ -38,11 +38,11 @@
 (defun make-connection-pool (&optional (max-active-connections *max-active-connections*))
   (make-lru-pool :hash-table (make-hash-table :test 'equal) :max-elts max-active-connections))
 
+(defvar *connection-pool* nil)
+
 (defun make-new-connection-pool (&optional (max-active-connections *max-active-connections*))
   (clear-connection-pool)
   (setf *connection-pool* (make-connection-pool max-active-connections)))
-
-(defvar *connection-pool* nil)
 
 (defun get-from-lru-pool (lru-pool key)
   "Takes an element from the LRU-POOL matching KEY.  Must be called with LRU-POOL-LOCK held.


### PR DESCRIPTION
Chunked keep alive streams were incorrectly tracking the state of the chunked stream and truncating data when hitting CRLF.  This was done to presumably allow either manual or automatic connection pooling.  We now allow chunga to do all the work and detect when it finishes reading chunked data and push the resulting stream back to the pool.

Also fix a finalizer bug when users do :want-stream t :keep-alive t :use-connection-pool nil -- probably never triggered in the real world.

Fixes #121 