### PR TITLE
Allow restarting with :insecure t.

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -496,7 +496,11 @@
                (retry-request ()
                  :report "Retry the same request."
                  (return-from request
-                   (apply #'request uri :use-connection-pool nil args)))))
+                   (apply #'request uri :use-connection-pool nil args)))
+               (retry-insecure ()
+                 :report "Retry the same request without checking for SSL certificate validity."
+                 (return-from request
+                   (apply #'request uri :use-connection-pool nil :insecure t args)))))
            (http-proxy-p (uri)
              (and uri
                   (let ((scheme (uri-scheme uri)))

--- a/src/backend/winhttp.lisp
+++ b/src/backend/winhttp.lisp
@@ -238,6 +238,9 @@
                       (retry-request ()
                         :report "Retry the same request."
                         (apply #'request uri args))
+                      (retry-request ()
+                        :report "Retry the same request without checking for SSL certificate validity."
+                        (apply #'request uri :insecure t args))
                       (ignore-and-continue ()
                         :report "Ignore the error and continue.")))
 


### PR DESCRIPTION
This allows the user of Dexador to restart the request with `:insecure t`. It's insecure, but useful for websites with self-siged or expired certs that one wants to access nonetheless.