### PR TITLE
Fix dex:ignore-and-continue not to retry endlessly.

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -676,8 +676,7 @@
                           ,@body)
                       (retry-request () :report "Retry the same request."
                         (return-from request (apply #'request uri args)))
-                      (ignore-and-continue () :report "Ignore the error and continue."
-                        (try-again-without-reusing-stream)))))
+                      (ignore-and-continue () :report "Ignore the error and continue."))))
         (tagbody
          retry
 


### PR DESCRIPTION
`dex:ignore-and-continue` won't ignore errors and retry endlessly.

Maybe after #123?