### PR TITLE
support 308 redirect

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -723,7 +723,7 @@
                                                                                    (uri-host uri)
                                                                                    (uri-path uri))))
                                                       set-cookies)))))
-               (when (and (member status '(301 302 303 307) :test #'=)
+               (when (and (member status '(301 302 303 307 308) :test #'=)
                           (gethash "location" response-headers)
                           (/= max-redirects 0))
                  ;; Need to read the response body
@@ -745,7 +745,7 @@
                                                 (eql (uri-port location-uri)
                                                      (uri-port uri))))))
                    (if (and same-server-p
-                            (or (= status 307)
+                            (or (= status 307) (= status 308)
                                 (member method '(:get :head) :test #'eq)))
                        (progn ;; redirection to the same host
                          (setq uri (merge-uris location-uri uri))
@@ -771,7 +771,7 @@
                          (setf (getf args :max-redirects)
                                (1- max-redirects))
                          ;; Redirect as GET if it's 301, 302, 303
-                         (unless (or (= status 307)
+                         (unless (or (= status 307) (= status 308)
                                      (member method '(:get :head) :test #'eq))
                            (setf (getf args :method) :get))
                          (return-from request

--- a/src/backend/winhttp.lisp
+++ b/src/backend/winhttp.lisp
@@ -201,7 +201,7 @@
                                                      set-cookies)))))
 
               ;; Redirect
-              (when (and (member status '(301 302 303 307))
+              (when (and (member status '(301 302 303 307 308))
                          (gethash "location" response-headers)
                          (/= max-redirects 0))
                 (let ((location-uri (quri:uri (gethash "location" response-headers))))
@@ -213,7 +213,7 @@
                                                      (quri:uri-host uri))
                                             (eql (quri:uri-port location-uri)
                                                  (quri:uri-port uri))))
-                                   (or (= status 307)
+                                   (or (= status 307) (= status 308)
                                        (member method '(:get :head) :test #'eq)))
                               method
                               :get)))


### PR DESCRIPTION
308 redirect is like 307, in that it should not switch method from post to get as 301 and 302 do. 308 means permanent redirect while 307 means temporary, same as 302 meaning permanent while 301 temporary but I think that just matters for browsers not us.

Here are some url returning 308 redirect:
https://docs.rs/crate/rustc-ap-rustc_errors/195.0.0/
https://docs.rs/crate/erg_proc_macros/0.6.22/
https://docs.rs/crate/async-global-executor/latest/
https://docs.rs/crate/erg_common/0.5.11-nightly.4/
dexador won't follow, after patch it will