### PR TITLE
decode application/javascript responses

### DIFF
--- a/src/encoding.lisp
+++ b/src/encoding.lisp
@@ -50,11 +50,17 @@
                nil)
            :utf-8))
       ((and (string-equal type "application")
-            (string-equal subtype "json"))
+            (or (string-equal subtype "json")
+                (string-equal subtype "javascript")))
        ;; According to RFC4627 (http://www.ietf.org/rfc/rfc4627.txt),
        ;; JSON text SHALL be encoded in Unicode. The default encoding is UTF-8.
        ;; It's possible to determine if the encoding is UTF-16 or UTF-36
        ;; by looking at the first four octets, however, I leave it to the future.
+       ;;
+       ;; According to RFC4329 (https://datatracker.ietf.org/doc/html/rfc4329),
+       ;; javascript also is specified by charset, or defaults to UTF-8
+       ;; It's also possible to specify in the first four octets, but
+       ;; like application/json I leave it to the future.
        (charset-to-encoding charset :utf-8))
       ((and (string-equal type "application")
             (ppcre:scan "(?:[^+]+\\+)?xml" subtype))


### PR DESCRIPTION
right now downloading any javascript file, for example:

```
(dex:get "https://github.githubassets.com/assets/github-elements-3485f2997bc6.js")
```

returns the result as octets vector. We normally want it as a string. Like application/json it can come from explicitly specified charset or default to utf-8. Also like application/json the encoding can be specified in the first four octets but I'm lazy and don't need for my use case now so I left for later