### PR TITLE
fix for *print-case* :downcase

### DIFF
--- a/src/error.lisp
+++ b/src/error.lisp
@@ -65,7 +65,7 @@
                        status)))))
 
 (defmacro define-request-failed-condition (name code)
-  `(define-condition ,(intern (format nil "~A-~A" :http-request name)) (http-request-failed)
+  `(define-condition ,(alexandria:format-symbol t "~A-~A" :http-request name) (http-request-failed)
      ()
      (:report (lambda (condition stream)
                 (with-slots (body uri) condition
@@ -111,7 +111,7 @@
                                     (http-version-not-supported . 505))
              collect `(define-request-failed-condition ,name ,code)
              collect `(setf (gethash ,code *request-failed-error*)
-                            ',(intern (format nil "~A-~A" :http-request name)))))
+                            ',(alexandria:format-symbol t "~A-~A" :http-request name))))
 
 (defun http-request-failed (status &key body headers uri method)
   (cerror


### PR DESCRIPTION
address issue https://github.com/fukamachi/dexador/issues/158 for users that have `*print-case*` set to `:downcase` by using `alexandria:format-symbol`