### PR TITLE
Feat: add bearer authorization

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -119,7 +119,10 @@ Dexador adopts [cl-cookie](https://github.com/fukamachi/cl-cookie) for its cooki
 ;   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 ```
 
-### Basic Authorization
+### Authorization
+You can only supply either basic or bearer authorization.
+
+#### Basic Authorization
 
 ```common-lisp
 (dex:head "http://www.hatena.ne.jp/" :basic-auth '("nitro_idiot" . "password") :verbose t)
@@ -129,6 +132,20 @@ Dexador adopts [cl-cookie](https://github.com/fukamachi/cl-cookie) for its cooki
 ;   Host: www.hatena.ne.jp
 ;   Accept: */*
 ;   Authorization: Basic bml0cm9faWRpb3Q6cGFzc3dvcmQ=
+;
+;   >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+```
+#### Bearer Authorization
+
+```common-lisp
+(dex:head "http://www.hatena.ne.jp/" :bearer-auth "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                                     :verbose t)
+;-> >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+;   HEAD / HTTP/1.1
+;   User-Agent: Dexador/0.9.15 (SBCL 2.4.3); Linux; 6.7.0-20-amd64
+;   Host: www.hatena.ne.jp
+;   Accept: */*
+;   Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
 ;   
 ;   >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 ```

--- a/src/backend/winhttp.lisp
+++ b/src/backend/winhttp.lisp
@@ -101,7 +101,7 @@
 (defun request (uri &rest args
                             &key (method :get) (version 1.1)
                             content headers
-                            basic-auth
+                            basic-auth bearer-auth
                             cookie-jar
                             (connect-timeout *default-connect-timeout*) (read-timeout *default-read-timeout*)
                             (keep-alive t) (use-connection-pool t)
@@ -158,6 +158,12 @@
               ((quri:uri-userinfo uri)
                (destructuring-bind (user pass) (split-sequence #\: (quri:uri-userinfo uri))
                  (set-credentials req user pass)))
+	      ((and basic-auth bearer-auth)
+	       (error "You should only use one Authorization header."))
+	      (bearer-auth
+	       (setf headers
+		     (append headers
+			     (list (cons "Authorization" (concatenate 'string "Bearer " bearer-auth))))))
               (basic-auth
                (set-credentials req (car basic-auth) (cdr basic-auth))))
 

--- a/src/dexador.lisp
+++ b/src/dexador.lisp
@@ -45,8 +45,9 @@
 (in-package :dexador)
 
 (defun get (uri &rest args
-            &key version headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout max-redirects
-              force-binary force-string want-stream content
+            &key version headers basic-auth bearer-auth cookie-jar keep-alive use-connection-pool
+	      connect-timeout read-timeout max-redirects
+	      force-binary force-string want-stream content
               ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path)
   "Make a GET request to URI and return
     (values body-or-stream status response-headers uri &optional opaque-socket-stream)
@@ -73,48 +74,69 @@
   for subsequent calls.
 
   While CONTENT is allowed in a GET request the results are ill-defined and not advised."
-  (declare (ignore version headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout max-redirects force-binary force-string want-stream ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path content))
+  (declare (ignore version headers basic-auth bearer-auth cookie-jar keep-alive use-connection-pool
+		   connect-timeout read-timeout max-redirects force-binary force-string want-stream
+		   ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path content))
   (apply #'request uri :method :get args))
 
 (defun post (uri &rest args
-             &key version content headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout
+             &key version content headers basic-auth bearer-auth cookie-jar keep-alive
+	       use-connection-pool connect-timeout read-timeout
                force-binary force-string want-stream
                ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path)
-  (declare (ignore version content headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout force-binary force-string want-stream ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path))
+  (declare (ignore version content headers basic-auth bearer-auth cookie-jar keep-alive
+		   use-connection-pool connect-timeout read-timeout force-binary force-string
+		   want-stream ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy
+		   insecure ca-path))
   (apply #'request uri :method :post args))
 
 (defun head (uri &rest args
-             &key version headers basic-auth cookie-jar connect-timeout read-timeout max-redirects
+             &key version headers basic-auth bearer-auth cookie-jar connect-timeout read-timeout max-redirects
                ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path)
-  (declare (ignore version headers basic-auth cookie-jar connect-timeout read-timeout max-redirects ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path))
+  (declare (ignore version headers basic-auth bearer-auth cookie-jar connect-timeout read-timeout
+		   max-redirects ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path))
   (apply #'request uri :method :head :use-connection-pool nil args))
 
 (defun put (uri &rest args
-            &key version content headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout
+            &key version content headers basic-auth bearer-auth cookie-jar keep-alive
+	      use-connection-pool connect-timeout read-timeout
               force-binary force-string want-stream
               ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path)
-  (declare (ignore version content headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout force-binary force-string want-stream ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path))
+  (declare (ignore version content headers basic-auth bearer-auth cookie-jar keep-alive
+		   use-connection-pool connect-timeout read-timeout force-binary force-string
+		   want-stream ssl-key-file ssl-cert-file ssl-key-password stream verbose
+		   proxy insecure ca-path))
   (apply #'request uri :method :put args))
 
 (defun patch (uri &rest args
-              &key version content headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout
+              &key version content headers basic-auth bearer-auth cookie-jar keep-alive
+		use-connection-pool connect-timeout read-timeout
                 force-binary force-string want-stream
                 ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path)
-  (declare (ignore version content headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout force-binary force-string want-stream ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path))
+  (declare (ignore version content headers basic-auth bearer-auth cookie-jar keep-alive
+		   use-connection-pool connect-timeout read-timeout force-binary force-string
+		   want-stream ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy
+		   insecure ca-path))
   (apply #'request uri :method :patch args))
 
 (defun delete (uri &rest args
-               &key version headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout
+               &key version headers basic-auth bearer-auth cookie-jar keep-alive
+		 use-connection-pool connect-timeout read-timeout
                  force-binary force-string want-stream content
                  ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path)
-  (declare (ignore version headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout force-binary force-string want-stream ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path content))
+  (declare (ignore version headers basic-auth bearer-auth cookie-jar keep-alive use-connection-pool
+		   connect-timeout read-timeout force-binary force-string want-stream ssl-key-file
+		   ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path content))
   (apply #'request uri :method :delete args))
 
 (defun fetch (uri destination &rest args
                   &key (if-exists :error)
-                    version headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout max-redirects
+                    version headers basic-auth bearer-auth cookie-jar keep-alive use-connection-pool
+		    connect-timeout read-timeout max-redirects
                     ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path)
-  (declare (ignore version headers basic-auth cookie-jar keep-alive use-connection-pool connect-timeout read-timeout max-redirects ssl-key-file ssl-cert-file ssl-key-password stream verbose proxy insecure ca-path))
+  (declare (ignore version headers basic-auth bearer-auth cookie-jar keep-alive use-connection-pool
+		   connect-timeout read-timeout max-redirects ssl-key-file ssl-cert-file
+		   ssl-key-password stream verbose proxy insecure ca-path))
   (unless (and (eql if-exists nil)
                (probe-file destination))
     (with-open-file (out destination


### PR DESCRIPTION
- Add bearer authorization option to all request methods
- Break keyword parameter lines so they do not exceed 100 chars
- Expand authorization section in readme

Nowadays a lot of API use Bearer instead of Basic Authorization.

I was not sure how to best implement tests for the request headers.
I tested on Linux X86 and on Windows and bearer-auth works for me on both. 

