### PR TITLE
Add dexador-usocket system for Windows

### DIFF
--- a/dexador-usocket.asd
+++ b/dexador-usocket.asd
@@ -1,0 +1,4 @@
+(defsystem "dexador-usocket"
+  :depends-on ("dexador"
+               (:feature (:not :dexador-no-ssl) "cl+ssl"))
+  :components ((:file "backend/usocket")))

--- a/dexador.asd
+++ b/dexador.asd
@@ -44,7 +44,7 @@
                  (:module "backend"
                   :depends-on ("encoding" "connection-cache" "decoding-stream" "keep-alive-stream" "body" "error" "util")
                   :components
-                  ((:file "usocket")
+                  ((:file "usocket" :if-feature (:not :windows))
                    (:file "winhttp" :if-feature :windows))))))
   :description "Yet another HTTP client for Common Lisp"
   :in-order-to ((test-op (test-op "dexador-test"))))

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -60,7 +60,7 @@
                 :merge-uris)
   (:import-from :cl-base64
                 :string-to-base64-string)
-  #-(or windows dexador-no-ssl)
+  #-dexador-no-ssl
   (:import-from :cl+ssl
                 :with-global-context
                 :make-context
@@ -362,9 +362,9 @@
            (fail 'dexador.error:socks5-proxy-request-failed :reason "Unknown address")))))))
 
 (defun make-ssl-stream (stream ca-path ssl-key-file ssl-cert-file ssl-key-password hostname insecure)
-  #+(or windows dexador-no-ssl)
+  #+dexador-no-ssl
   (error "SSL not supported. Remove :dexador-no-ssl from *features* to enable SSL.")
-  #-(or windows dexador-no-ssl)
+  #-dexador-no-ssl
   (progn
     (cl+ssl:ensure-initialized)
     (let ((ctx (cl+ssl:make-context :verify-mode

--- a/src/dexador.lisp
+++ b/src/dexador.lisp
@@ -1,9 +1,7 @@
 (in-package :cl-user)
 (uiop:define-package dexador
   (:nicknames :dex)
-  (:use :cl
-        #-windows #:dexador.backend.usocket
-        #+windows #:dexador.backend.winhttp)
+  (:use :cl)
   (:shadow :get
            :delete)
   (:import-from :dexador.connection-cache
@@ -43,6 +41,45 @@
            :ignore-and-continue)
   (:use-reexport :dexador.error))
 (in-package :dexador)
+
+(defvar *dexador-backend*
+  #+windows :winhttp
+  #-windows :usocket)
+
+(defun request (uri &rest args
+                    &key method version
+                         content headers
+                         basic-auth bearer-auth
+                         cookie-jar
+                         connect-timeout read-timeout
+                         keep-alive use-connection-pool
+                         max-redirects
+                         ssl-key-file ssl-cert-file ssl-key-password
+                         stream verbose
+                         force-binary
+                         force-string
+                         want-stream
+                         proxy
+                         insecure
+                         ca-path)
+  (declare (ignore method version
+                   content headers
+                   basic-auth bearer-auth
+                   cookie-jar
+                   connect-timeout read-timeout
+                   keep-alive use-connection-pool
+                   max-redirects
+                   ssl-key-file ssl-cert-file ssl-key-password
+                   stream verbose
+                   force-binary
+                   force-string
+                   want-stream
+                   proxy
+                   insecure
+                   ca-path))
+  (ecase *dexador-backend*
+    (:usocket (apply #'uiop:symbol-call '#:dexador.backend.usocket '#:request uri args))
+    (:winhttp (apply #'uiop:symbol-call '#:dexador.backend.winhttp '#:request uri args))))
 
 (defun get (uri &rest args
             &key version headers basic-auth bearer-auth cookie-jar keep-alive use-connection-pool

--- a/src/dexador.lisp
+++ b/src/dexador.lisp
@@ -38,7 +38,9 @@
 
            ;; Restarts
            :retry-request
-           :ignore-and-continue)
+           :ignore-and-continue
+
+           :*dexador-backend*)
   (:use-reexport :dexador.error))
 (in-package :dexador)
 


### PR DESCRIPTION
Add a system "dexador-usocket" for Windows to load the usocket backend explicitly.

```common-lisp
(ql:quickload '(:dexador :dexador-usocket))
(setf dexador:*dexador-backend* :usocket)
```

ref #172 