### PR TITLE
Fix failure in auto-retry when connection-cache is used and server drops connection

### DIFF
--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -653,18 +653,18 @@
 
            ;; Sending the content
            (when content
-             (let ((stream (if chunkedp
-                               (chunga:make-chunked-stream stream)
-                               stream)))
+             (let ((encoding-stream (if chunkedp
+				       (chunga:make-chunked-stream stream)
+				       stream)))
                (when chunkedp
-                 (setf (chunga:chunked-stream-output-chunking-p stream) t))
+                 (setf (chunga:chunked-stream-output-chunking-p encoding-stream) t))
                (with-retrying
                  (if (consp content)
-                     (dexador.body:write-multipart-content content boundary stream)
-                     (dexador.body:write-as-octets stream content))
+                     (dexador.body:write-multipart-content content boundary encoding-stream)
+                     (dexador.body:write-as-octets encoding-stream content))
                  (when chunkedp
-                   (setf (chunga:chunked-stream-output-chunking-p stream) nil))
-                 (finish-output stream))))
+                   (setf (chunga:chunked-stream-output-chunking-p encoding-stream) nil))
+                 (finish-output encoding-stream))))
 
          start-reading
            (multiple-value-bind (http body response-headers-data transfer-encoding-p)


### PR DESCRIPTION
Unsafe with-retrying macrolet uses variables from outside of them (in particular: 'stream'), we were caught by 'stream' being locally bound around one of the with-retrying clauses.  This caused the auto-retry when re-using a connection pool connection when the connection has been closed by the server to not work depending on when the stream error occurred (I think the stream error usually occurs before this clause, when writing the headers, but I had a reproducible case where it did not).  The symptom was getting an error that we were trying to reuse a closed SSL-STREAM.