### PR TITLE
Use `~@:(~A~)` instead of `~A` when interning the symbol. 

### DIFF
--- a/src/body.lisp
+++ b/src/body.lisp
@@ -71,13 +71,13 @@
               #\Return #\Newline))))
 
 (defmacro define-alist-cache (cache-name)
-  (let ((var (intern (format nil "*~A*" cache-name))))
+  (let ((var (intern (format nil "*~@:(~A~)*" cache-name))))
   `(progn
      (defvar ,var)
-     (defun ,(intern (format nil "LOOKUP-IN-~A" cache-name)) (elt)
+     (defun ,(intern (format nil "LOOKUP-IN-~@:(~A~)" cache-name)) (elt)
        (when (boundp ',var)
          (alexandria:assoc-value ,var elt)))
-     (defun (setf ,(intern (format nil "LOOKUP-IN-~A" cache-name))) (val elt)
+     (defun (setf ,(intern (format nil "LOOKUP-IN-~@:(~A~)" cache-name))) (val elt)
        (when (boundp ',var)
          (setf (alexandria:assoc-value ,var elt) val))
        val))))

--- a/src/error.lisp
+++ b/src/error.lisp
@@ -65,7 +65,8 @@
                        status)))))
 
 (defmacro define-request-failed-condition (name code)
-  `(define-condition ,(intern (format nil "~A-~A" :http-request name)) (http-request-failed)
+  `(define-condition ,(intern (format nil "~@:(~A~)-~@:(~A~)" :http-request name))
+       (http-request-failed)
      ()
      (:report (lambda (condition stream)
                 (with-slots (body uri) condition
@@ -111,7 +112,7 @@
                                     (http-version-not-supported . 505))
              collect `(define-request-failed-condition ,name ,code)
              collect `(setf (gethash ,code *request-failed-error*)
-                            ',(intern (format nil "~A-~A" :http-request name)))))
+                            ',(intern (format nil "~@:(~A~)-~@:(~A~)" :http-request name)))))
 
 (defun http-request-failed (status &key body headers uri method)
   (cerror


### PR DESCRIPTION
Fix when *print-case* is :downcase using ~@:(~A~) for upstring print. 