### PR TITLE
Pass :element-type to keep-alive-stream make-instance calls

### DIFF
--- a/src/keep-alive-stream.lisp
+++ b/src/keep-alive-stream.lisp
@@ -42,8 +42,16 @@
 keep-alive-stream), and should handle clean-up of it"
   (assert (xor end chunked-stream))
   (if chunked-stream
-      (make-instance 'keep-alive-chunked-stream :stream stream :chunga-stream chunked-stream :on-close-or-eof on-close-or-eof)
-      (make-instance 'keep-alive-stream :stream stream :end end :on-close-or-eof on-close-or-eof)))
+      (make-instance 'keep-alive-chunked-stream
+                     :stream stream
+                     :chunga-stream chunked-stream
+                     :on-close-or-eof on-close-or-eof
+                     #+allegro :element-type #+allegro '(unsigned-byte 8))
+      (make-instance 'keep-alive-stream
+                     :stream stream
+                     :end end
+                     :on-close-or-eof on-close-or-eof
+                     #+allegro :element-type #+allegro '(unsigned-byte 8))))
 
 (defun maybe-close (stream &optional (close-if nil))
   "Will close the underlying stream if close-if is T (unless it is already closed).


### PR DESCRIPTION
## What
Pass `:element-type '(unsigned-byte 8)` to `make-instance` calls in `make-keep-alive-stream`

## Why
Allegro CL 11 requires an explicit `:element-type` initarg when instantiating stream classes derived from gray streams. Without it, requests with `:use-connection-pool t :keep-alive t :want-stream t` error out: "make-instance on this stream class requires a :ELEMENT-TYPE initarg".

Other implementations (SBCL, CCL, etc.) accept but don't require the initarg, so nothing changes for them.

Fixes #198