### PR TITLE
Fix cookie test failure with cl-cookie 0.2.0

### DIFF
--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -412,7 +412,10 @@
                   302
                   200)
               ;; mixi.jp
-              '(:set-cookie "_auid=a8acafbaef245a806f6a308506dc95c8; domain=localhost; path=/; expires=Mon, 10-Jul-2017 12:32:47 GMT"
+              ;; No Domain attribute: cl-cookie 0.2.0 rejects domains that don't
+              ;; match the origin host (RFC 6265 5.3), and the test server host
+              ;; differs between environments (localhost vs 127.0.0.1).
+              '(:set-cookie "_auid=a8acafbaef245a806f6a308506dc95c8; path=/; expires=Mon, 10-Jul-2017 12:32:47 GMT"
                 ;; sourceforge
                 :set-cookie2 "VISITOR=55a11217d3179d198af1d003; expires=\"Tue, 08-Jul-2025 12:54:47 GMT\"; httponly; Max-Age=315360000; Path=/")
               '("ok")))


### PR DESCRIPTION
## Summary

CI on macOS and Windows (and the daily scheduled runs on master) currently fails in `USING-COOKIES-TESTS`: the jar ends up with 1 cookie instead of 2.

Cause: cl-cookie 0.2.0 (April 2026) rejects `Set-Cookie` headers whose `Domain` attribute does not domain-match the origin host (RFC 6265 §5.3 step 6, with a warning). The test hardcodes `domain=localhost`, but `clack.test` connects via `127.0.0.1` on those platforms, so the first cookie is rejected. The Linux job passes only because its Docker image resolves the test host as `localhost`.

Fix: drop the `Domain` attribute from the test's `Set-Cookie` header so the cookie is host-only and independent of the test server host.

## Test plan

- [x] `using-cookies-tests` passes with the older cl-cookie (2024 dist)
- [x] `using-cookies-tests` passes with cl-cookie master (0.2.0)
- [x] Full `dexador-test` suite passes locally on SBCL/macOS

Made with [Cursor](https://cursor.com)