### PR TITLE
Proxy support for env / registry / automatic scripts. Including IPv6

### DIFF
--- a/.github/mitmproxy-addon.py
+++ b/.github/mitmproxy-addon.py
@@ -1,0 +1,10 @@
+"""Add Via and forward decrypted HTTPS requests to the HTTP test origin."""
+
+from mitmproxy import http
+
+
+def request(flow: http.HTTPFlow) -> None:
+    via = flow.request.headers.get("Via")
+    flow.request.headers["Via"] = f"{via}, 1.1 mitmproxy" if via else "1.1 mitmproxy"
+    if flow.request.scheme == "https":
+        flow.request.scheme = "http"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,18 @@ on:
   schedule:
     - cron: '0 15 * * *'
 
+# Proxy integration tests (dexador-integration-test) run against real mitmproxy
+# instances (plain :3128, Basic-auth :3129, SOCKS5 :3130); see .github/mitmproxy-addon.py.
+# HTTPS-through-proxy tests trust mitmproxy's self-signed CA, exported per job
+# as DEXADOR_TEST_PROXY_CA (and imported into the Windows certificate store).
+env:
+  DEXADOR_TEST_PROXY: http://127.0.0.1:3128
+  DEXADOR_TEST_AUTH_PROXY: http://127.0.0.1:3129
+  DEXADOR_TEST_SOCKS5_PROXY: socks5://127.0.0.1:3130
+
 jobs:
   test_linux:
-    name: ${{ matrix.lisp }} on ${{ matrix.os }}
+    name: ${{ matrix.lisp }} on ${{ matrix.os }} (Docker)
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -20,16 +29,35 @@ jobs:
       - name: Run tests
         run: make test
 
-  test_mac:
+  test_unix:
     name: ${{ matrix.lisp }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         lisp: [sbcl-bin]
-        os: [macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
 
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Start test proxies
+        run: |
+          pip install mitmproxy
+          mitmdump --mode regular --listen-host 127.0.0.1 --listen-port 3128 \
+            -s .github/mitmproxy-addon.py \
+            --set upstream_cert=false --set connection_strategy=lazy -q &
+          mitmdump --mode regular --listen-host 127.0.0.1 --listen-port 3129 \
+            -s .github/mitmproxy-addon.py --proxyauth dexador:test \
+            --set upstream_cert=false --set connection_strategy=lazy -q &
+          mitmdump --mode socks5  --listen-host 127.0.0.1 --listen-port 3130 -s .github/mitmproxy-addon.py -q &
+          for _ in $(seq 1 30); do
+            test -f "$HOME/.mitmproxy/mitmproxy-ca-cert.pem" && break
+            sleep 1
+          done
+          test -f "$HOME/.mitmproxy/mitmproxy-ca-cert.pem"
+          echo "DEXADOR_TEST_PROXY_CA=$HOME/.mitmproxy/mitmproxy-ca-cert.pem" >> "$GITHUB_ENV"
       - name: Install Roswell
         env:
           LISP: ${{ matrix.lisp }}
@@ -43,6 +71,10 @@ jobs:
         run: |
           PATH="~/.roswell/bin:$PATH"
           rove dexador-test.asd
+      - name: Run proxy integration tests
+        run: |
+          PATH="~/.roswell/bin:$PATH"
+          rove dexador-integration-test.asd
 
   test_windows:
     name: ${{ matrix.lisp }} on ${{ matrix.os }}
@@ -62,6 +94,49 @@ jobs:
         with:
           update: true
           install: mingw-w64-x86_64-openssl
+      # The winhttp backend tests need an origin reachable through a
+      # non-loopback address (WinHTTP never proxies loopback targets), and
+      # the system-proxy discovery tests rewrite the runner's registry
+      # proxy settings (HKCU Internet Settings), which is fine on a
+      # disposable runner.
+      - name: Enable winhttp proxy tests
+        shell: pwsh
+        run: |
+          $ip = (Get-NetIPAddress -AddressFamily IPv4 |
+                 Where-Object { $_.InterfaceAlias -notmatch 'Loopback' -and $_.IPAddress -notmatch '^169\.254\.' } |
+                 Select-Object -First 1).IPAddress
+          echo "DEXADOR_TEST_ORIGIN_HOST=$ip" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "DEXADOR_TEST_MUTATE_SYSTEM_PROXY=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          New-NetFirewallRule -DisplayName dexador-test-origin `
+            -Direction Inbound -Action Allow -Protocol TCP `
+            -LocalPort 50000-60000 | Out-Null
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Start test proxies
+        shell: pwsh
+        run: |
+          pip install mitmproxy
+          $tls = @('--set','upstream_cert=false','--set','connection_strategy=lazy')
+          $plain = @('--mode','regular','--listen-host','127.0.0.1',
+                     '--listen-port','3128','-s','.github/mitmproxy-addon.py')
+          $auth = @('--mode','regular','--listen-host','127.0.0.1',
+                    '--listen-port','3129','-s','.github/mitmproxy-addon.py',
+                    '--proxyauth','dexador:test')
+          $socks = @('--mode','socks5','--listen-host','127.0.0.1',
+                     '--listen-port','3130','-s','.github/mitmproxy-addon.py','-q')
+          Start-Process mitmdump -ArgumentList ($plain + $tls + @('-q'))
+          Start-Process mitmdump -ArgumentList ($auth + $tls + @('-q'))
+          Start-Process mitmdump -ArgumentList $socks
+          $cert = "$env:USERPROFILE\.mitmproxy\mitmproxy-ca-cert.cer"
+          for ($i = 0; $i -lt 30 -and !(Test-Path $cert); $i++) {
+            Start-Sleep 1
+          }
+          if (!(Test-Path $cert)) { throw "mitmproxy CA was not generated" }
+          # Trust the generated CA: certificate store for winhttp, env var for cl+ssl.
+          certutil -addstore -f Root $cert
+          $ca = "$env:USERPROFILE\.mitmproxy\mitmproxy-ca-cert.pem"
+          echo "DEXADOR_TEST_PROXY_CA=$ca" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Install Roswell
         env:
           LISP: ${{ matrix.lisp }}
@@ -76,3 +151,6 @@ jobs:
       - name: Run tests
         run: |
           ros -e '(handler-bind ((error (lambda (e) (uiop:print-condition-backtrace e) (uiop:quit -1)))) (ql:quickload :dexador-test))' -e '(or (rove:run :dexador-test) (uiop:quit -1))'
+      - name: Run proxy integration tests
+        run: |
+          ros -e '(handler-bind ((error (lambda (e) (uiop:print-condition-backtrace e) (uiop:quit -1)))) (ql:quickload :dexador-integration-test))' -e '(or (rove:run :dexador-integration-test) (uiop:quit -1))'

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@
 *.lx32fsl
 *.lx64fsl
 *.x86f
+*.pyc
+__pycache__/
 *~
 .#*

--- a/README.markdown
+++ b/README.markdown
@@ -222,9 +222,37 @@ You can connect via SOCKS5 proxy.
 (dex:get "https://www.facebookcorewwwi.onion/" :proxy "socks5://127.0.0.1:9150")
 ```
 
-You can set the default proxy by setting
-```dex:*default-proxy*```
-which defaults to the value of the environment variable HTTPS_PROXY or HTTP_PROXY
+You can set the default proxy by setting `dex:*default-proxy*`, which defaults to the
+environment variables `https_proxy` / `http_proxy` (with an `all_proxy` fallback).
+
+`:proxy` (and `dex:*default-proxy*`) may also be an alist mapping a scheme,
+`scheme://host`, or `"*"`/`"all"` to a proxy URL — the Common Lisp equivalent of the
+`proxies` dict in Python's *requests*. The most specific key wins (`scheme://host`, then
+scheme, then `"*"`):
+
+```common-lisp
+(setf dex:*default-proxy*
+      '(("https" . "http://proxy.yourcompany.com:8080/")
+        ("http"  . "http://proxy.yourcompany.com:8080/")
+        ("https://internal.git" . "http://10.0.0.1:3128/")
+        ("*"     . "socks5://127.0.0.1:9150")))
+```
+
+#### Bypassing the proxy (`NO_PROXY`)
+
+`dex:*no-proxy*` lists hosts that bypass the proxy, defaulting to the `no_proxy` /
+`NO_PROXY` environment variable. It is a comma/space-separated string (or a list) of
+patterns; `"*"` bypasses every host. When the target host is an IP address (IPv4 or IPv6),
+it is compared against IP and CIDR patterns; otherwise a pattern matches the host exactly
+or as a domain suffix (a leading dot and any `:port` are ignored):
+
+```common-lisp
+(let ((dex:*no-proxy* "localhost,.internal.example.com,10.0.0.0/8,::1"))
+  (dex:get "https://api.internal.example.com/")) ; connects directly, ignoring the proxy
+```
+
+Proxy URLs may carry credentials as `user:pass@host`. Proxy support currently requires the
+usocket backend (not supported on Windows).
 
 ## Functions
 
@@ -268,8 +296,8 @@ All functions take similar arguments.
 <!-- - `force-string` -->
 - `want-stream` (boolean)
   - A flag to get the response body as a stream.
-- `proxy` (string)
-  - for use proxy. defaults to the value of `dex:*default-proxy*` which defaults to the value of environment variables HTTPS_PROXY or HTTP_PROXY.  Not supported on windows currently
+- `proxy` (string or scheme/host alist)
+  - Proxy to use. A URL string (applied to every scheme) or a *requests*-style alist mapping a scheme / `scheme://host` / `"*"` to a proxy URL. Defaults to `dex:*default-proxy*` (seeded from `https_proxy` / `http_proxy` / `all_proxy`). Hosts matching `dex:*no-proxy*` (seeded from `no_proxy`) bypass the proxy. Not supported on Windows currently.
 - `insecure` (boolean)
   - To bypass SSL certificate verification (use at your own risk). The default is `NIL`, the value of `*not-verify-ssl*`.
 <!-- - `ca-path` -->

--- a/README.markdown
+++ b/README.markdown
@@ -241,7 +241,63 @@ You can bypass the proxy for particular hosts by setting `dex:*no-proxy*`, which
   (dex:get "https://api.internal.example.com/")) ; connects directly, ignoring the proxy
 ```
 
-Proxy URLs may carry credentials as `user:pass@host`. Proxy support is not available on Windows currently.
+Proxy URLs may carry credentials as `user:pass@host`.
+
+#### Proxies on Windows
+
+**Behavior change:** older Dexador releases always connected directly on Windows
+(the WinHTTP backend ignored proxies and `http_proxy`). The WinHTTP backend now
+honors `:proxy` / `dex:*default-proxy*` (including env vars) and, when none is
+set, discovers the system proxy (Internet Options / PAC / WPAD) via
+`dex:*use-system-proxy*` (default `T`). Set it to `NIL` to restore the old
+always-direct behavior when no explicit proxy is given:
+
+```common-lisp
+(setf dex:*use-system-proxy* nil)
+```
+
+HTTP proxies are supported (Basic credentials as `user:pass@host`); SOCKS5 is
+not. For SOCKS5, load the usocket backend instead:
+
+```common-lisp
+(ql:quickload :dexador-usocket)
+(setf dex:*dexador-backend* :usocket)
+```
+
+Note that WinHTTP never proxies requests to loopback addresses (`localhost`, `127.0.0.1`).
+
+#### Single sign-on (Windows)
+
+The WinHTTP backend answers `Negotiate` (Kerberos/SPNEGO) and `NTLM`
+authentication challenges from servers *and* proxies (via
+`WinHttpQueryAuthSchemes` + `WinHttpSetCredentials`). When no explicit
+credentials are supplied, it uses the logged-on user's credentials — single
+sign-on against corporate proxies and intranet servers — controlled by
+`dex:*use-default-credentials*` (default `T`).
+
+Which hosts receive those credentials is controlled by
+`dex:*winhttp-autologon-policy*` (default `:medium` = intranet zone only, the
+WinHTTP default). Do **not** set `:low` outside controlled environments: it
+sends credentials to any host that challenges with NTLM/Negotiate.
+
+```common-lisp
+;; Uses the current user's credentials for intranet Negotiate/NTLM challenges:
+(dex:get "https://intranet.corp/api")
+
+(setf dex:*use-default-credentials* nil) ; never send the logged-on credentials
+
+;; Unsafe: allow SSO against any host (e.g. an IP that is not in the intranet zone)
+(setf dex:*winhttp-autologon-policy* :low)
+```
+
+Explicit credentials still take precedence and work with whichever scheme the peer selects (Basic, Digest, NTLM, Negotiate):
+
+```common-lisp
+(dex:get "https://intranet.corp/api" :basic-auth '("DOMAIN\\user" . "pass"))
+(dex:get "https://user:pass@intranet.corp/api")
+```
+
+This is WinHTTP-only; the usocket backend supports Basic and Bearer authentication only.
 
 ## Functions
 
@@ -286,7 +342,7 @@ All functions take similar arguments.
 - `want-stream` (boolean)
   - A flag to get the response body as a stream.
 - `proxy` (string or alist)
-  - for use proxy. A proxy URL string or an alist mapping a scheme / `scheme://host` / `"*"` to proxy URLs. Defaults to the value of `dex:*default-proxy*`. Hosts matching `dex:*no-proxy*` bypass the proxy. Not supported on windows currently
+  - for use proxy. A proxy URL string or an alist mapping a scheme / `scheme://host` / `"*"` to proxy URLs. Defaults to the value of `dex:*default-proxy*`. Hosts matching `dex:*no-proxy*` bypass the proxy. The WinHTTP backend (the Windows default) supports HTTP proxies only and additionally discovers the system proxy (registry / PAC / WPAD) when none is given (see `dex:*use-system-proxy*`); use the usocket backend (`dexador-usocket`) for SOCKS5 on Windows
 - `insecure` (boolean)
   - To bypass SSL certificate verification (use at your own risk). The default is `NIL`, the value of `*not-verify-ssl*`.
 <!-- - `ca-path` -->

--- a/README.markdown
+++ b/README.markdown
@@ -226,9 +226,8 @@ You can set the default proxy by setting `dex:*default-proxy*`, which defaults t
 environment variables `https_proxy` / `http_proxy` (with an `all_proxy` fallback).
 
 `:proxy` (and `dex:*default-proxy*`) may also be an alist mapping a scheme,
-`scheme://host`, or `"*"`/`"all"` to a proxy URL — the Common Lisp equivalent of the
-`proxies` dict in Python's *requests*. The most specific key wins (`scheme://host`, then
-scheme, then `"*"`):
+`scheme://host`, or `"*"`/`"all"` to a proxy URL. The most specific key wins
+(`scheme://host`, then scheme, then `"*"`):
 
 ```common-lisp
 (setf dex:*default-proxy*
@@ -297,7 +296,7 @@ All functions take similar arguments.
 - `want-stream` (boolean)
   - A flag to get the response body as a stream.
 - `proxy` (string or scheme/host alist)
-  - Proxy to use. A URL string (applied to every scheme) or a *requests*-style alist mapping a scheme / `scheme://host` / `"*"` to a proxy URL. Defaults to `dex:*default-proxy*` (seeded from `https_proxy` / `http_proxy` / `all_proxy`). Hosts matching `dex:*no-proxy*` (seeded from `no_proxy`) bypass the proxy. Not supported on Windows currently.
+  - Proxy to use. A URL string (applied to every scheme) or an alist mapping a scheme / `scheme://host` / `"*"` to a proxy URL. Defaults to `dex:*default-proxy*` (seeded from `https_proxy` / `http_proxy` / `all_proxy`). Hosts matching `dex:*no-proxy*` (seeded from `no_proxy`) bypass the proxy. Not supported on Windows currently.
 - `insecure` (boolean)
   - To bypass SSL certificate verification (use at your own risk). The default is `NIL`, the value of `*not-verify-ssl*`.
 <!-- - `ca-path` -->

--- a/README.markdown
+++ b/README.markdown
@@ -222,12 +222,9 @@ You can connect via SOCKS5 proxy.
 (dex:get "https://www.facebookcorewwwi.onion/" :proxy "socks5://127.0.0.1:9150")
 ```
 
-You can set the default proxy by setting `dex:*default-proxy*`, which defaults to the
-environment variables `https_proxy` / `http_proxy` (with an `all_proxy` fallback).
+You can set the default proxy by setting `dex:*default-proxy*`, which defaults to the value of the environment variable `https_proxy`, `http_proxy` or `all_proxy`. When only one of them is set, it is used for both HTTP and HTTPS.
 
-`:proxy` (and `dex:*default-proxy*`) may also be an alist mapping a scheme,
-`scheme://host`, or `"*"`/`"all"` to a proxy URL. The most specific key wins
-(`scheme://host`, then scheme, then `"*"`):
+You can use different proxies for different schemes or hosts by giving an alist. The most specific key wins: `scheme://host`, then a scheme, then `"*"` (or `"all"`).
 
 ```common-lisp
 (setf dex:*default-proxy*
@@ -237,21 +234,14 @@ environment variables `https_proxy` / `http_proxy` (with an `all_proxy` fallback
         ("*"     . "socks5://127.0.0.1:9150")))
 ```
 
-#### Bypassing the proxy (`NO_PROXY`)
-
-`dex:*no-proxy*` lists hosts that bypass the proxy, defaulting to the `no_proxy` /
-`NO_PROXY` environment variable. It is a comma/space-separated string (or a list) of
-patterns; `"*"` bypasses every host. When the target host is an IP address (IPv4 or IPv6),
-it is compared against IP and CIDR patterns; otherwise a pattern matches the host exactly
-or as a domain suffix (a leading dot and any `:port` are ignored):
+You can bypass the proxy for particular hosts by setting `dex:*no-proxy*`, which defaults to the value of the environment variable `no_proxy`. It is a comma-separated string (or a list) of patterns. A hostname matches a pattern exactly or as a domain suffix, an IP address matches IP and CIDR patterns like `10.0.0.0/8`, and `"*"` matches every host.
 
 ```common-lisp
 (let ((dex:*no-proxy* "localhost,.internal.example.com,10.0.0.0/8,::1"))
   (dex:get "https://api.internal.example.com/")) ; connects directly, ignoring the proxy
 ```
 
-Proxy URLs may carry credentials as `user:pass@host`. Proxy support currently requires the
-usocket backend (not supported on Windows).
+Proxy URLs may carry credentials as `user:pass@host`. Proxy support is not available on Windows currently.
 
 ## Functions
 
@@ -295,8 +285,8 @@ All functions take similar arguments.
 <!-- - `force-string` -->
 - `want-stream` (boolean)
   - A flag to get the response body as a stream.
-- `proxy` (string or scheme/host alist)
-  - Proxy to use. A URL string (applied to every scheme) or an alist mapping a scheme / `scheme://host` / `"*"` to a proxy URL. Defaults to `dex:*default-proxy*` (seeded from `https_proxy` / `http_proxy` / `all_proxy`). Hosts matching `dex:*no-proxy*` (seeded from `no_proxy`) bypass the proxy. Not supported on Windows currently.
+- `proxy` (string or alist)
+  - for use proxy. A proxy URL string or an alist mapping a scheme / `scheme://host` / `"*"` to proxy URLs. Defaults to the value of `dex:*default-proxy*`. Hosts matching `dex:*no-proxy*` bypass the proxy. Not supported on windows currently
 - `insecure` (boolean)
   - To bypass SSL certificate verification (use at your own risk). The default is `NIL`, the value of `*not-verify-ssl*`.
 <!-- - `ca-path` -->

--- a/dexador-integration-test.asd
+++ b/dexador-integration-test.asd
@@ -1,0 +1,16 @@
+(defsystem "dexador-integration-test"
+  :author "Eitaro Fukamachi"
+  :license "MIT"
+  :description "Integration tests against a real external proxy (see .github/workflows/ci.yml)"
+  :defsystem-depends-on ("trivial-features")
+  :depends-on ("dexador"
+               ;; usocket backend on Windows: covers SOCKS5 and the loopback
+               ;; origins that WinHTTP never proxies.
+               (:feature :windows "dexador-usocket")
+               "rove"
+               "clack-test"
+               "quri")
+  :components ((:module "t"
+                :components
+                ((:file "integration"))))
+  :perform (test-op (op c) (symbol-call '#:rove '#:run c)))

--- a/dexador-test.asd
+++ b/dexador-test.asd
@@ -6,13 +6,23 @@
 (defsystem "dexador-test"
   :author "Eitaro Fukamachi"
   :license "MIT"
+  :defsystem-depends-on ("trivial-features")
   :depends-on ("dexador"
+               ;; usocket backend on Windows: the unit proxy tests target
+               ;; loopback origins, which WinHTTP never proxies.
+               (:feature :windows "dexador-usocket")
                "rove"
                "lack-request"
                "clack-test"
                "babel"
-               "cl-cookie")
+               "cl-cookie"
+               "usocket"
+               "bordeaux-threads"
+               "cl-base64"
+               "quri")
   :components ((:module "t"
                 :components
-                ((:file "dexador"))))
+                ((:file "proxy-server")
+                 (:file "ntlm-server")
+                 (:file "dexador" :depends-on ("proxy-server" "ntlm-server")))))
   :perform (test-op (op c) (symbol-call '#:rove '#:run c)))

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -413,10 +413,11 @@
                             force-binary
                             force-string
                             want-stream
-                            (proxy *default-proxy*)
+                            ((:proxy proxy-arg) *default-proxy*)
                             (insecure *not-verify-ssl*)
                             ca-path
                             &aux
+                            (proxy (resolve-proxy uri proxy-arg))
                             (proxy-uri (and proxy (quri:uri proxy)))
                             (original-user-supplied-stream stream)
                             (user-supplied-stream (if (usocket-wrapped-stream-p stream) (usocket-wrapped-stream-stream stream) stream)))

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -429,7 +429,8 @@
   (labels ((make-new-connection (uri)
              (restart-case
                  (let* ((con-uri (quri:uri (or proxy uri)))
-                        (connection (usocket:socket-connect (uri-host con-uri)
+                        ;; usocket wants a bare IPv6 address, not the RFC 2732 "[::1]" URL form.
+                        (connection (usocket:socket-connect (strip-ipv6-brackets (uri-host con-uri))
                                                             (uri-port con-uri)
                                                             #-(or ecl clasp clisp allegro) :timeout #-(or ecl clasp clisp allegro) connect-timeout
                                                             :element-type '(unsigned-byte 8)))

--- a/src/backend/usocket.lisp
+++ b/src/backend/usocket.lisp
@@ -430,9 +430,13 @@
              (restart-case
                  (let* ((con-uri (quri:uri (or proxy uri)))
                         ;; usocket wants a bare IPv6 address, not the RFC 2732 "[::1]" URL form.
+                        ;; SBCL on Windows: usocket's connect deadline machinery signals a
+                        ;; spurious EINTR, so don't pass :timeout there.
                         (connection (usocket:socket-connect (strip-ipv6-brackets (uri-host con-uri))
                                                             (uri-port con-uri)
-                                                            #-(or ecl clasp clisp allegro) :timeout #-(or ecl clasp clisp allegro) connect-timeout
+                                                            #-(or ecl clasp clisp allegro (and sbcl win32)) :timeout
+                                                            #-(or ecl clasp clisp allegro (and sbcl win32))
+                                                            connect-timeout
                                                             :element-type '(unsigned-byte 8)))
                         (stream
                           (usocket:socket-stream connection))
@@ -526,9 +530,14 @@
                               (equalp (cdr transfer-encoding) "chunked"))
                          (and content-length
                               (null (cdr content-length)))))
+           ;; Plain-http requests sent to an HTTP proxy use the RFC 7230 absolute-form
+           ;; target; https goes through a CONNECT tunnel and keeps origin-form.
+           ;; Recomputed on redirects (see below) so a scheme change cannot leave a
+           ;; stale absolute/origin-form choice.
+           (proxied-http-p (and proxy (string= (uri-scheme uri) "http")))
            (first-line-data
              (with-fast-output (buffer)
-               (write-first-line method uri version buffer)))
+               (write-first-line method uri version buffer proxied-http-p)))
            (headers-data
              (flet ((write-header* (name value)
                       (let ((header (assoc name headers :test #'string-equal)))
@@ -731,9 +740,10 @@
                                      (member method '(:get :head) :test #'eq)))
                             (progn ;; redirection to the same host
                               (setq uri (merge-uris location-uri uri))
+                              (setq proxied-http-p (and proxy (string= (uri-scheme uri) "http")))
                               (setq first-line-data
                                     (with-fast-output (buffer)
-                                      (write-first-line method uri version buffer)))
+                                      (write-first-line method uri version buffer proxied-http-p)))
                               (when cookie-jar
                                 ;; Rebuild cookie-headers.
                                 (setq cookie-headers (build-cookie-headers uri cookie-jar)))

--- a/src/backend/winhttp.lisp
+++ b/src/backend/winhttp.lisp
@@ -31,6 +31,8 @@
                 #:when-let)
   (:import-from #:split-sequence
                 #:split-sequence)
+  (:import-from #:cl-base64
+                #:string-to-base64-string)
   (:export :request))
 (in-package #:dexador.backend.winhttp)
 
@@ -38,6 +40,186 @@
 (defconstant +WINHTTP_DISABLE_COOKIES+    #x00000001)
 (defconstant +WINHTTP_DISABLE_REDIRECTS+  #x00000002)
 (defconstant +WINHTTP_DISABLE_KEEP_ALIVE+ #x00000008)
+
+(defconstant +WINHTTP_OPTION_PROXY+ 38)
+(defconstant +WINHTTP_OPTION_AUTOLOGON_POLICY+ 77)
+;; Autologon security levels (WINHTTP_OPTION_AUTOLOGON_POLICY).
+(defconstant +WINHTTP_AUTOLOGON_SECURITY_LEVEL_MEDIUM+ 0)
+(defconstant +WINHTTP_AUTOLOGON_SECURITY_LEVEL_LOW+ 1)
+(defconstant +WINHTTP_AUTOLOGON_SECURITY_LEVEL_HIGH+ 2)
+(defconstant +WINHTTP_ACCESS_TYPE_NO_PROXY+ 1)
+(defconstant +WINHTTP_ACCESS_TYPE_NAMED_PROXY+ 3)
+;; Windows 8.1+: resolve the proxy per request from WinINet (registry) settings,
+;; PAC scripts and WPAD, falling back to direct when nothing is configured.
+(defconstant +WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY+ 4)
+
+;; WinHttpQueryAuthSchemes / WinHttpSetCredentials scheme bitflags.
+(defconstant +WINHTTP_AUTH_SCHEME_BASIC+ 1)
+(defconstant +WINHTTP_AUTH_SCHEME_NTLM+ 2)
+(defconstant +WINHTTP_AUTH_SCHEME_DIGEST+ 8)
+(defconstant +WINHTTP_AUTH_SCHEME_NEGOTIATE+ 16)
+(defconstant +ERROR_INVALID_PARAMETER+ 87)
+
+(cffi:defcstruct winhttp-proxy-info
+  (access-type :uint32)
+  (proxy :pointer)
+  (bypass :pointer))
+
+(cffi:defcfun (%query-auth-schemes "WinHttpQueryAuthSchemes" :convention :stdcall) :boolean
+  (hreq :pointer)
+  (supported-schemes :pointer)
+  (first-scheme :pointer)
+  (auth-target :pointer))
+
+(defun open-session (user-agent access-type)
+  (winhttp::with-wide-string (u user-agent)
+    (let ((h (winhttp::%http-open u access-type (cffi:null-pointer) (cffi:null-pointer) 0)))
+      (when (cffi:null-pointer-p h)
+        (winhttp::get-last-error))
+      h)))
+
+(defun open-http-session (user-agent system-proxy-p)
+  (if system-proxy-p
+      (handler-case (open-session user-agent +WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY+)
+        (winhttp::win-error (e)
+          ;; AUTOMATIC_PROXY requires Windows 8.1.
+          (if (= (winhttp::win-error-code e) +ERROR_INVALID_PARAMETER+)
+              (open-session user-agent +WINHTTP_ACCESS_TYPE_NO_PROXY+)
+              (error e))))
+      (open-session user-agent +WINHTTP_ACCESS_TYPE_NO_PROXY+)))
+
+(defmacro with-http-session ((var user-agent system-proxy-p) &body body)
+  `(let ((,var (open-http-session ,user-agent ,system-proxy-p)))
+     (unwind-protect (progn ,@body)
+       (winhttp::close-handle ,var))))
+
+(defun autologon-policy-value ()
+  "DWORD for WINHTTP_OPTION_AUTOLOGON_POLICY."
+  (if (not *use-default-credentials*)
+      +WINHTTP_AUTOLOGON_SECURITY_LEVEL_HIGH+
+      (ecase *winhttp-autologon-policy*
+        (:medium +WINHTTP_AUTOLOGON_SECURITY_LEVEL_MEDIUM+)
+        (:low +WINHTTP_AUTOLOGON_SECURITY_LEVEL_LOW+)
+        (:high +WINHTTP_AUTOLOGON_SECURITY_LEVEL_HIGH+))))
+
+(defun set-request-credentials (req target scheme user pass)
+  "WinHttpSetCredentials wrapper. A NULL USER answers Negotiate/NTLM challenges
+with the logged-on user's credentials (single sign-on)."
+  (flet ((%set (u p)
+           (unless (winhttp::%set-credentials req
+                                              (ecase target (:server 0) (:proxy 1))
+                                              (ecase scheme
+                                                (:basic +WINHTTP_AUTH_SCHEME_BASIC+)
+                                                (:ntlm +WINHTTP_AUTH_SCHEME_NTLM+)
+                                                (:digest +WINHTTP_AUTH_SCHEME_DIGEST+)
+                                                (:negotiate +WINHTTP_AUTH_SCHEME_NEGOTIATE+))
+                                              u p (cffi:null-pointer))
+             (winhttp::get-last-error))))
+    (if user
+        (winhttp::with-wide-string (u user)
+          (winhttp::with-wide-string (p (or pass ""))
+            (%set u p)))
+        (%set (cffi:null-pointer) (cffi:null-pointer)))))
+
+(defun query-auth-schemes (req)
+  "Call WinHttpQueryAuthSchemes. Returns (VALUES supported-bitmask preferred-scheme
+auth-target) or NIL when the call fails (e.g. no challenge pending)."
+  (cffi:with-foreign-objects ((supported :uint32)
+                              (first :uint32)
+                              (target :uint32))
+    (when (%query-auth-schemes req supported first target)
+      (values (cffi:mem-ref supported :uint32)
+              (cffi:mem-ref first :uint32)
+              (cffi:mem-ref target :uint32)))))
+
+(defun select-auth-scheme-from-mask (supported)
+  "Return the strongest scheme in SUPPORTED."
+  (loop for (flag key) in `((,+WINHTTP_AUTH_SCHEME_NEGOTIATE+ :negotiate)
+                            (,+WINHTTP_AUTH_SCHEME_NTLM+ :ntlm)
+                            (,+WINHTTP_AUTH_SCHEME_DIGEST+ :digest)
+                            (,+WINHTTP_AUTH_SCHEME_BASIC+ :basic))
+        when (plusp (logand supported flag))
+          return key))
+
+(defun select-auth-scheme-from-header (challenge)
+  "Fallback when WinHttpQueryAuthSchemes is unavailable: parse a
+WWW-Authenticate / Proxy-Authenticate header value."
+  (when challenge
+    ;; Splitting on commas also cuts inside Digest parameter lists
+    ;; (qop=\"auth,auth-int\"); the stray pieces simply match no scheme name.
+    (let ((tokens (loop for part in (split-sequence #\, challenge)
+                        for trimmed = (string-trim " " part)
+                        collect (subseq trimmed 0 (or (position #\Space trimmed)
+                                                      (length trimmed))))))
+      (loop for (name key) in '(("Negotiate" :negotiate) ("NTLM" :ntlm)
+                                ("Digest" :digest) ("Basic" :basic))
+            when (member name tokens :test #'string-equal)
+              return key))))
+
+(defun userinfo-credentials (uri)
+  (let ((userinfo (and uri (quri:uri-userinfo uri))))
+    (when userinfo
+      (let ((colon (position #\: userinfo)))
+        (if colon
+            (cons (subseq userinfo 0 colon) (subseq userinfo (1+ colon)))
+            (cons userinfo ""))))))
+
+(defun drain-response-body (req)
+  "Consume any remaining response body so the request handle can be resent."
+  (let ((buffer (make-array 4096 :element-type '(unsigned-byte 8))))
+    (loop for bytes = (read-data req buffer)
+          until (zerop bytes))))
+
+(defun answer-auth-challenge (req status response-headers uri proxy-uri basic-auth)
+  "Set credentials on REQ for a 401/407 challenge; true when the request
+should be resent. Uses WinHttpQueryAuthSchemes when available (required for
+Digest and the documented SetCredentials flow), falling back to header parsing.
+Explicit credentials (URL userinfo / BASIC-AUTH) are used with whatever scheme
+the peer selected; Negotiate/NTLM challenges without explicit credentials fall
+back to single sign-on when *USE-DEFAULT-CREDENTIALS* is true."
+  (multiple-value-bind (supported preferred queried-target)
+      (query-auth-schemes req)
+    (declare (ignore preferred))
+    (multiple-value-bind (target creds scheme)
+        (if supported
+            (let* ((target (if (= queried-target 1) :proxy :server))
+                   (creds (if (eq target :proxy)
+                              (userinfo-credentials proxy-uri)
+                              (or (userinfo-credentials uri) basic-auth)))
+                   (scheme (select-auth-scheme-from-mask supported)))
+              (values target creds scheme))
+            ;; QueryAuthSchemes failed: fall back to status + header parsing.
+            (let* ((target (if (eql status 407) :proxy :server))
+                   (challenge (gethash (if (eq target :proxy)
+                                           "proxy-authenticate"
+                                           "www-authenticate")
+                                       response-headers))
+                   (creds (if (eq target :proxy)
+                              (userinfo-credentials proxy-uri)
+                              (or (userinfo-credentials uri) basic-auth)))
+                   (scheme (select-auth-scheme-from-header challenge)))
+              (values target creds scheme)))
+      (when scheme
+        (cond
+          (creds
+           (set-request-credentials req target scheme (car creds) (cdr creds))
+           t)
+          ((and *use-default-credentials* (member scheme '(:negotiate :ntlm)))
+           (set-request-credentials req target scheme nil nil)
+           t))))))
+
+(defun set-request-proxy (req proxy-uri)
+  "Route REQ through PROXY-URI by setting WINHTTP_OPTION_PROXY on the request handle."
+  (winhttp::with-wide-string (p (format-host-port (quri:uri-host proxy-uri)
+                                                  (quri:uri-port proxy-uri)))
+    (cffi:with-foreign-object (info '(:struct winhttp-proxy-info))
+      (setf (cffi:foreign-slot-value info '(:struct winhttp-proxy-info) 'access-type)
+            +WINHTTP_ACCESS_TYPE_NAMED_PROXY+
+            (cffi:foreign-slot-value info '(:struct winhttp-proxy-info) 'proxy) p
+            (cffi:foreign-slot-value info '(:struct winhttp-proxy-info) 'bypass) (cffi:null-pointer))
+      (unless (winhttp::%set-option req +WINHTTP_OPTION_PROXY+ info
+                                    (cffi:foreign-type-size '(:struct winhttp-proxy-info)))
+        (winhttp::get-last-error)))))
 
 (defun set-option (req var value &optional (type :uint32))
   (cffi:with-foreign-object (buf type)
@@ -107,15 +289,21 @@
                             stream (verbose *verbose*)
                             force-binary force-string
                             want-stream
-                            proxy
+                            ((:proxy proxy-arg) *default-proxy*)
                             (insecure *not-verify-ssl*)
                             ca-path)
   (declare (ignore version use-connection-pool
                    ssl-key-file ssl-cert-file ssl-key-password
                    stream verbose
-                   proxy
                    ca-path))
   (let* ((uri (quri:uri uri))
+         (proxy-url (resolve-proxy uri proxy-arg))
+         (proxy-uri (and proxy-url (quri:uri proxy-url)))
+         ;; No explicit proxy: let Windows resolve one (registry, PAC, WPAD)
+         ;; unless disabled or the host is bypassed via *no-proxy*.
+         (system-proxy-p (and (null proxy-uri)
+                              *use-system-proxy*
+                              (not (host-bypassed-p (quri:uri-host uri) *no-proxy*))))
          (content-type
            (find :content-type headers :key #'car :test #'string-equal))
          (multipart-p (or (and content-type
@@ -144,7 +332,11 @@
             (setf headers
                   (append headers
                           `(("Cookie" . ,(write-cookie-header cookies))))))))
-      (with-http (session (or user-agent *default-user-agent*))
+      (when (and proxy-uri (string-equal (quri:uri-scheme proxy-uri) "socks5"))
+        (error "SOCKS5 proxies are not supported by the WinHTTP backend: ~A~%~
+                Load dexador-usocket and set dex:*dexador-backend* to :usocket instead."
+               proxy-url))
+      (with-http-session (session (or user-agent *default-user-agent*) system-proxy-p)
         (with-connect (conn session (quri:uri-host uri) (quri:uri-port uri))
           (with-request (req conn :verb method
                                   :url (format nil "~@[~A~]~@[?~A~]"
@@ -164,13 +356,33 @@
               (basic-auth
                (set-credentials req (car basic-auth) (cdr basic-auth))))
 
+            (when proxy-uri
+              (set-request-proxy req proxy-uri)
+              (let ((userinfo (quri:uri-userinfo proxy-uri)))
+                (when userinfo
+                  (destructuring-bind (user &optional (pass "")) (split-sequence #\: userinfo)
+                    (set-credentials req user pass :basic :proxy))
+                  ;; For plain HTTP the request goes to the proxy directly, so we can
+                  ;; authenticate proactively instead of waiting for a 407 challenge.
+                  (unless (or (equalp (quri:uri-scheme uri) "https")
+                              (find "proxy-authorization" headers :key #'car :test #'string-equal))
+                    (setf headers
+                          (append headers
+                                  (list (cons "Proxy-Authorization"
+                                              (concatenate 'string "Basic "
+                                                           (string-to-base64-string userinfo))))))))))
+
             ;; TODO: SSL arguments
-            ;; TODO: proxy support
             (set-option req
                         +WINHTTP_OPTION_DISABLE_FEATURE+
                         (logior +WINHTTP_DISABLE_COOKIES+
                                 +WINHTTP_DISABLE_REDIRECTS+
                                 (if keep-alive 0 +WINHTTP_DISABLE_KEEP_ALIVE+)))
+
+            ;; Control single sign-on. Default *winhttp-autologon-policy* is
+            ;; :MEDIUM (intranet only). :LOW would send credentials to any host.
+            (set-option req +WINHTTP_OPTION_AUTOLOGON_POLICY+
+                        (autologon-policy-value))
 
             (dolist (header headers)
               (add-request-headers req
@@ -188,6 +400,27 @@
             (send-request req content)
 
             (receive-response req)
+
+            ;; Auth challenge loop: reuse the same request handle so that
+            ;; connection-oriented handshakes (NTLM, Negotiate) keep their
+            ;; connection and SSPI context. Credentials are set once per
+            ;; target; a further 401/407 is a handshake continuation and is
+            ;; only resent -- calling WinHttpSetCredentials again mid-
+            ;; handshake would reset the SSPI context back to the first leg.
+            (loop with answered = ()
+                  repeat 3
+                  for status = (query-status-code req)
+                  while (member status '(401 407))
+                  do (let ((target (if (eql status 407) :proxy :server))
+                           (response-headers (query-headers* req)))
+                       (unless (or (member target answered)
+                                   (answer-auth-challenge req status response-headers
+                                                          uri proxy-uri basic-auth))
+                         (loop-finish))
+                       (pushnew target answered)
+                       (drain-response-body req)
+                       (send-request req content)
+                       (receive-response req)))
 
             (let ((status (query-status-code req))
                   (response-headers (query-headers* req)))

--- a/src/dexador.lisp
+++ b/src/dexador.lisp
@@ -14,6 +14,9 @@
                 :*default-read-timeout*
                 :*default-proxy*
                 :*no-proxy*
+                :*use-system-proxy*
+                :*use-default-credentials*
+                :*winhttp-autologon-policy*
                 :*verbose*
                 :*not-verify-ssl*)
   (:import-from :alexandria
@@ -31,6 +34,9 @@
            :*default-read-timeout*
            :*default-proxy*
            :*no-proxy*
+           :*use-system-proxy*
+           :*use-default-credentials*
+           :*winhttp-autologon-policy*
            :*verbose*
            :*not-verify-ssl*
            :*connection-pool*

--- a/src/dexador.lisp
+++ b/src/dexador.lisp
@@ -13,6 +13,7 @@
                 :*default-connect-timeout*
                 :*default-read-timeout*
                 :*default-proxy*
+                :*no-proxy*
                 :*verbose*
                 :*not-verify-ssl*)
   (:import-from :alexandria
@@ -29,6 +30,7 @@
            :*default-connect-timeout*
            :*default-read-timeout*
            :*default-proxy*
+           :*no-proxy*
            :*verbose*
            :*not-verify-ssl*
            :*connection-pool*

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -40,16 +40,13 @@
 (defvar *default-read-timeout* 10)
 (defvar *verbose* nil)
 (defvar *not-verify-ssl* nil)
+
 (defun getenv-nonempty (&rest names)
-  "Return the first non-empty environment variable value among NAMES, or NIL."
   (loop for name in names
         thereis (let ((v (uiop:getenv name)))
                   (and v (plusp (length v)) v))))
 
 (defun environment-proxy ()
-  "Build a proxy configuration from the environment, Python-requests style.
-Reads per-scheme https_proxy/http_proxy (lower- and upper-case) plus an all_proxy
-fallback. Returns an alist mapping \"https\"/\"http\"/\"*\" to proxy URLs, or NIL."
   #+windows nil
   #-windows
   (let ((https (getenv-nonempty "https_proxy" "HTTPS_PROXY"))
@@ -60,33 +57,31 @@ fallback. Returns an alist mapping \"https\"/\"http\"/\"*\" to proxy URLs, or NI
                       (and all (cons "*" all))))))
 
 (defvar *default-proxy* (environment-proxy)
-  "Default proxy used by dexador, Python-requests style. Either:
- - NIL (no proxy),
- - a proxy URL string (used for every scheme), or
- - an alist mapping \"http\"/\"https\"/\"scheme://host\"/\"*\" (or \"all\") to proxy URLs.
-Defaults from the environment (https_proxy / http_proxy with an all_proxy fallback).
-Honors *NO-PROXY*. A proxy URL may carry credentials as user:pass@host and may use the
+  "Default proxy: NIL, a proxy URL string used for every scheme, or an alist mapping
+\"http\"/\"https\"/\"scheme://host\"/\"*\" (or \"all\") to proxy URLs. Defaults from the
+https_proxy / http_proxy environment variables with an all_proxy fallback. Honors
+*NO-PROXY*. A proxy URL may carry credentials as user:pass@host and may use the
 socks5:// scheme.")
 
 (defvar *no-proxy* (getenv-nonempty "no_proxy" "NO_PROXY")
-  "Hosts that bypass the proxy (cf. NO_PROXY). A comma/space-separated string or a list of
-patterns. \"*\" bypasses every host. An IP host is compared against IP and CIDR patterns
-(e.g. \"127.0.0.1\", \"10.0.0.0/8\", \"::1\", \"fd00::/8\"); any other host matches a
-pattern exactly or as a domain suffix (a leading dot and any :port in a pattern are
-ignored). Defaults from the no_proxy / NO_PROXY environment variable.")
+  "Hosts that bypass the proxy: a comma/space-separated string or a list of patterns.
+\"*\" bypasses every host. An IP host is compared against IP and CIDR patterns
+(e.g. \"10.0.0.0/8\", \"::1\"); any other host matches a pattern exactly or as a domain
+suffix. Defaults from the no_proxy / NO_PROXY environment variable.")
 
 (defun strip-ipv6-brackets (host)
-  "Return HOST without RFC 2732 brackets: \"[::1]\" or \"[::1]:8080\" -> \"::1\"."
-  (or (and (plusp (length host))
-           (char= (char host 0) #\[)
-           (let ((close (position #\] host)))
-             (and close (subseq host 1 close))))
+  "Strip RFC 2732 brackets: \"[::1]\" -> \"::1\"."
+  (if (and (plusp (length host))
+           (char= (char host 0) #\[))
+      (let ((close (position #\] host)))
+        (if close
+            (subseq host 1 close)
+            host))
       host))
 
 (defun parse-ip-address (string)
-  "Parse STRING as an IPv4 or IPv6 literal (IPv6 may be bracketed).
-Returns (VALUES address-integer total-bits) with TOTAL-BITS 32 or 128, or NIL when
-STRING is not an IP literal."
+  "Parse an IPv4 or IPv6 literal into (VALUES address-integer total-bits),
+or NIL when STRING is not an IP literal."
   (let ((string (strip-ipv6-brackets string)))
     (if (find #\: string)
         (let ((bytes (ignore-errors (ipv6-host-to-vector string))))
@@ -107,8 +102,7 @@ STRING is not an IP literal."
                   finally (return (values address 32))))))))
 
 (defun ip-in-network-p (address total-bits pattern)
-  "True if the IP (ADDRESS integer of TOTAL-BITS) lies in the CIDR network PATTERN,
-e.g. \"10.0.0.0/8\" or \"2001:db8::/32\". Host bits set in PATTERN are masked off."
+  "Test an IP against a CIDR network like \"10.0.0.0/8\" or \"2001:db8::/32\"."
   (let ((slash (position #\/ pattern)))
     (when slash
       (multiple-value-bind (network network-bits)
@@ -122,9 +116,8 @@ e.g. \"10.0.0.0/8\" or \"2001:db8::/32\". Host bits set in PATTERN are masked of
                   (ash network (- prefix network-bits)))))))))
 
 (defun ip-matches-pattern-p (address total-bits pattern)
-  "True if the IP (ADDRESS integer of TOTAL-BITS) matches PATTERN: a CIDR network, or an
-IP literal compared numerically (so \"::1\" matches \"0:0:0:0:0:0:0:1\"). A :port suffix
-is ignored on IPv4 and bracketed IPv6 patterns."
+  "Test an IP against a CIDR network or an IP literal (compared numerically,
+so \"::1\" matches \"0:0:0:0:0:0:0:1\"). A :port suffix in PATTERN is ignored."
   (if (find #\/ pattern)
       (ip-in-network-p address total-bits pattern)
       (multiple-value-bind (pattern-address pattern-bits)
@@ -136,6 +129,19 @@ is ignored on IPv4 and bracketed IPv6 patterns."
         (and pattern-address
              (eql total-bits pattern-bits)
              (= address pattern-address)))))
+
+(defun hostname-matches-pattern-p (host pattern)
+  "Test a hostname against a NO_PROXY pattern: exact match or domain suffix.
+A leading dot and any :port in PATTERN are ignored."
+  (let* ((dotless (string-left-trim "." pattern))
+         (pattern (subseq dotless 0 (position #\: dotless))))
+    (or (string-equal host pattern)
+        (let ((pl (length pattern))
+              (hl (length host)))
+          (and (plusp pl)
+               (> hl pl)
+               (char= (char host (- hl pl 1)) #\.)
+               (string-equal pattern (subseq host (- hl pl))))))))
 
 (defun host-bypassed-p (host no-proxy)
   "True if HOST should bypass the proxy according to NO-PROXY (NO_PROXY semantics).
@@ -150,26 +156,16 @@ domain suffix."
                                            (uiop:split-string no-proxy :separator ", "))
                                 :test #'string=))))
       (multiple-value-bind (address total-bits) (parse-ip-address host)
-        (some (lambda (raw)
-                (and (plusp (length raw))
-                     (or (string= raw "*")
+        (some (lambda (pattern)
+                (and (plusp (length pattern))
+                     (or (string= pattern "*")
                          (if address
-                             (ip-matches-pattern-p address total-bits raw)
-                             ;; Drop a leading dot and any :port, e.g. ".example.com:443"
-                             ;; -> "example.com", then match exactly or as domain suffix.
-                             (let* ((dotless (string-left-trim "." raw))
-                                    (pattern (subseq dotless 0 (position #\: dotless))))
-                               (or (string-equal host pattern)
-                                   (let ((pl (length pattern)) (hl (length host)))
-                                     (and (plusp pl)
-                                          (> hl pl)
-                                          (char= (char host (- hl pl 1)) #\.)
-                                          (string-equal pattern (subseq host (- hl pl)))))))))))
+                             (ip-matches-pattern-p address total-bits pattern)
+                             (hostname-matches-pattern-p host pattern)))))
               patterns)))))
 
 (defun normalize-proxy (proxy)
-  "Normalize PROXY to the scheme/host alist form: a plain URL string (the historical
-:PROXY value) becomes ((\"*\" . url))."
+  "Normalize PROXY to the alist form: a URL string becomes ((\"*\" . url))."
   (etypecase proxy
     (null nil)
     (string (list (cons "*" proxy)))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -167,19 +167,24 @@ domain suffix."
                                           (string-equal pattern (subseq host (- hl pl)))))))))))
               patterns)))))
 
-(defun proxy-for-uri (uri proxy)
-  "Select the proxy URL for URI from PROXY (NIL, a URL string, or a scheme/host alist)."
+(defun normalize-proxy (proxy)
+  "Normalize PROXY to the scheme/host alist form: a plain URL string (the historical
+:PROXY value) becomes ((\"*\" . url))."
   (etypecase proxy
     (null nil)
-    (string proxy)
-    (list
-     (let* ((scheme (uri-scheme uri))
-            (host (uri-host uri))
-            (host-key (and scheme host (format nil "~A://~A" scheme host))))
-       (cdr (or (and host-key (assoc host-key proxy :test #'string-equal))
-                (and scheme (assoc scheme proxy :test #'string-equal))
-                (assoc "*" proxy :test #'string-equal)
-                (assoc "all" proxy :test #'string-equal)))))))
+    (string (list (cons "*" proxy)))
+    (list proxy)))
+
+(defun proxy-for-uri (uri proxy)
+  "Select the proxy URL for URI from the scheme/host alist PROXY.
+The most specific key wins: \"scheme://host\", then scheme, then \"*\"/\"all\"."
+  (let* ((scheme (uri-scheme uri))
+         (host (uri-host uri))
+         (host-key (and scheme host (format nil "~A://~A" scheme host))))
+    (cdr (or (and host-key (assoc host-key proxy :test #'string-equal))
+             (and scheme (assoc scheme proxy :test #'string-equal))
+             (assoc "*" proxy :test #'string-equal)
+             (assoc "all" proxy :test #'string-equal)))))
 
 (defun resolve-proxy (uri proxy &optional (no-proxy *no-proxy*))
   "Return the effective proxy URL string for URI, or NIL.
@@ -187,7 +192,7 @@ PROXY is NIL, a URL string, or a scheme/host alist (see *DEFAULT-PROXY*). Return
 URI's host matches NO-PROXY."
   (let ((u (quri:uri uri)))
     (unless (host-bypassed-p (uri-host u) no-proxy)
-      (proxy-for-uri u proxy))))
+      (proxy-for-uri u (normalize-proxy proxy)))))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defvar *speedy-declaration* '(declare (optimize (speed 3) (safety 0) (space 0) (compilation-speed 0))))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -173,11 +173,15 @@ domain suffix."
 
 (defun proxy-for-uri (uri proxy)
   "Select the proxy URL for URI from the scheme/host alist PROXY.
-The most specific key wins: \"scheme://host\", then scheme, then \"*\"/\"all\"."
+The most specific key wins: \"scheme://host\", then scheme, then \"*\"/\"all\".
+IPv6 hosts are looked up both bare and bracketed so either key form matches."
   (let* ((scheme (uri-scheme uri))
-         (host (uri-host uri))
-         (host-key (and scheme host (format nil "~A://~A" scheme host))))
+         (host (and (uri-host uri) (strip-ipv6-brackets (uri-host uri))))
+         (host-key (and scheme host (format nil "~A://~A" scheme host)))
+         (bracketed-key (and scheme host (find #\: host)
+                             (format nil "~A://[~A]" scheme host))))
     (cdr (or (and host-key (assoc host-key proxy :test #'string-equal))
+             (and bracketed-key (assoc bracketed-key proxy :test #'string-equal))
              (and scheme (assoc scheme proxy :test #'string-equal))
              (assoc "*" proxy :test #'string-equal)
              (assoc "all" proxy :test #'string-equal)))))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -11,6 +11,7 @@
                 :uri-host
                 :uri-port
                 :uri-scheme
+                :copy-uri
                 :render-uri)
   (:import-from :usocket
                 :ipv6-host-to-vector)
@@ -19,9 +20,13 @@
            :*verbose*
            :*default-proxy*
            :*no-proxy*
+           :*use-system-proxy*
+           :*use-default-credentials*
+           :*winhttp-autologon-policy*
            :resolve-proxy
            :host-bypassed-p
            :strip-ipv6-brackets
+           :format-host-port
            :*not-verify-ssl*
            :defun-speedy
            :defun-careful
@@ -58,8 +63,6 @@
                     (and all (cons "*" all)))))
 
 (defun environment-proxy ()
-  #+windows nil
-  #-windows
   (let ((https (getenv-nonempty "https_proxy" "HTTPS_PROXY"))
         (http  (getenv-nonempty "http_proxy" "HTTP_PROXY"))
         (all   (getenv-nonempty "all_proxy" "ALL_PROXY")))
@@ -71,6 +74,30 @@
 https_proxy / http_proxy environment variables with an all_proxy fallback. If only one
 scheme-specific variable is set, it is used for both schemes. Honors *NO-PROXY*. A proxy
 URL may carry credentials as user:pass@host and may use the socks5:// scheme.")
+
+(defvar *use-system-proxy* t
+  "Windows/WinHTTP backend only: when T (default) and no proxy is given explicitly
+(via :PROXY or *DEFAULT-PROXY*), requests use the system proxy configuration --
+per-user WinINet settings (registry / Internet Options), PAC scripts and WPAD
+auto-discovery. Set to NIL to always connect directly unless a proxy is given.
+This is a behavior change from older Dexador releases, which always connected
+directly on Windows.")
+
+(defvar *use-default-credentials* t
+  "Windows/WinHTTP backend only: when T (default), Negotiate (Kerberos) and NTLM
+challenges from servers and proxies are answered with the logged-on user's
+credentials (single sign-on) when no explicit credentials were given. The hosts
+that receive those credentials are controlled by *WINHTTP-AUTOLOGON-POLICY*
+(default :MEDIUM = intranet zone only). Set to NIL to never send them.")
+
+(defvar *winhttp-autologon-policy* :medium
+  "Windows/WinHTTP backend only: when *USE-DEFAULT-CREDENTIALS* is true, which
+hosts may receive the logged-on credentials for Negotiate/NTLM.
+  :MEDIUM — intranet zone only (WinHTTP default; safe for corporate SSO)
+  :LOW    — any host (unsafe: any WWW-Authenticate: NTLM challenger can solicit
+            a Type 3 / relay; use only in controlled environments)
+  :HIGH   — never (same as *USE-DEFAULT-CREDENTIALS* = NIL)
+Ignored when *USE-DEFAULT-CREDENTIALS* is NIL (always treated as :HIGH).")
 
 (defvar *no-proxy* (getenv-nonempty "no_proxy" "NO_PROXY")
   "Hosts that bypass the proxy: a comma/space-separated string or a list of patterns.
@@ -87,6 +114,13 @@ suffix. Defaults from the no_proxy / NO_PROXY environment variable.")
             (subseq host 1 close)
             host))
       host))
+
+(defun format-host-port (host port)
+  "HOST:PORT, with IPv6 hosts in RFC 2732 brackets: \"[::1]:8080\"."
+  (let ((host (strip-ipv6-brackets host)))
+    (if (find #\: host)
+        (format nil "[~A]:~A" host port)
+        (format nil "~A:~A" host port))))
 
 (defun parse-ip-address (string)
   "Parse an IPv4 or IPv6 literal into (VALUES address-integer total-bits),
@@ -260,13 +294,19 @@ URI's host matches NO-PROXY."
 
 (defparameter *header-buffer* nil)
 
-(defun write-first-line (method uri version &optional (buffer *header-buffer*))
+(defun write-first-line (method uri version &optional (buffer *header-buffer*) absolute-form)
+  "Write the request line. With ABSOLUTE-FORM, the target is the full URI as
+required by RFC 7230 for requests sent to an HTTP proxy. Userinfo is never
+written into the request line (credentials belong in Authorization /
+Proxy-Authorization headers)."
   (fast-write-sequence (ascii-string-to-octets (string method)) buffer)
   (fast-write-byte #.(char-code #\Space) buffer)
   (fast-write-sequence (ascii-string-to-octets
-                         (format nil "~A~:[~;~:*?~A~]"
-                                 (or (uri-path uri) "/")
-                                 (uri-query uri)))
+                         (if absolute-form
+                             (render-uri (copy-uri uri :userinfo nil :fragment nil))
+                             (format nil "~A~:[~;~:*?~A~]"
+                                     (or (uri-path uri) "/")
+                                     (uri-query uri))))
                        buffer)
   (fast-write-byte #.(char-code #\Space) buffer)
   (fast-write-sequence (ecase version

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -46,22 +46,31 @@
         thereis (let ((v (uiop:getenv name)))
                   (and v (plusp (length v)) v))))
 
+(defun make-environment-proxy (https http all)
+  (unless all
+    (cond
+      ((and https (null http))
+       (setf http https))
+      ((and http (null https))
+       (setf https http))))
+  (remove nil (list (and https (cons "https" https))
+                    (and http (cons "http" http))
+                    (and all (cons "*" all)))))
+
 (defun environment-proxy ()
   #+windows nil
   #-windows
   (let ((https (getenv-nonempty "https_proxy" "HTTPS_PROXY"))
         (http  (getenv-nonempty "http_proxy" "HTTP_PROXY"))
         (all   (getenv-nonempty "all_proxy" "ALL_PROXY")))
-    (remove nil (list (and https (cons "https" https))
-                      (and http (cons "http" http))
-                      (and all (cons "*" all))))))
+    (make-environment-proxy https http all)))
 
 (defvar *default-proxy* (environment-proxy)
   "Default proxy: NIL, a proxy URL string used for every scheme, or an alist mapping
 \"http\"/\"https\"/\"scheme://host\"/\"*\" (or \"all\") to proxy URLs. Defaults from the
-https_proxy / http_proxy environment variables with an all_proxy fallback. Honors
-*NO-PROXY*. A proxy URL may carry credentials as user:pass@host and may use the
-socks5:// scheme.")
+https_proxy / http_proxy environment variables with an all_proxy fallback. If only one
+scheme-specific variable is set, it is used for both schemes. Honors *NO-PROXY*. A proxy
+URL may carry credentials as user:pass@host and may use the socks5:// scheme.")
 
 (defvar *no-proxy* (getenv-nonempty "no_proxy" "NO_PROXY")
   "Hosts that bypass the proxy: a comma/space-separated string or a list of patterns.

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -10,11 +10,18 @@
                 :uri-query
                 :uri-host
                 :uri-port
+                :uri-scheme
                 :render-uri)
+  (:import-from :usocket
+                :ipv6-host-to-vector)
   (:export :*default-connect-timeout*
            :*default-read-timeout*
            :*verbose*
            :*default-proxy*
+           :*no-proxy*
+           :resolve-proxy
+           :host-bypassed-p
+           :strip-ipv6-brackets
            :*not-verify-ssl*
            :defun-speedy
            :defun-careful
@@ -33,10 +40,154 @@
 (defvar *default-read-timeout* 10)
 (defvar *verbose* nil)
 (defvar *not-verify-ssl* nil)
-(defvar *default-proxy* (or #-windows (uiop:getenv "HTTPS_PROXY")
-                            #-windows (uiop:getenv "HTTP_PROXY"))
-  "If specified will be used as the default value of PROXY in calls to dexador.  Defaults to
- the value of the environment variable HTTPS_PROXY or HTTP_PROXY if not on Windows.")
+(defun getenv-nonempty (&rest names)
+  "Return the first non-empty environment variable value among NAMES, or NIL."
+  (loop for name in names
+        thereis (let ((v (uiop:getenv name)))
+                  (and v (plusp (length v)) v))))
+
+(defun environment-proxy ()
+  "Build a proxy configuration from the environment, Python-requests style.
+Reads per-scheme https_proxy/http_proxy (lower- and upper-case) plus an all_proxy
+fallback. Returns an alist mapping \"https\"/\"http\"/\"*\" to proxy URLs, or NIL."
+  #+windows nil
+  #-windows
+  (let ((https (getenv-nonempty "https_proxy" "HTTPS_PROXY"))
+        (http  (getenv-nonempty "http_proxy" "HTTP_PROXY"))
+        (all   (getenv-nonempty "all_proxy" "ALL_PROXY")))
+    (remove nil (list (and https (cons "https" https))
+                      (and http (cons "http" http))
+                      (and all (cons "*" all))))))
+
+(defvar *default-proxy* (environment-proxy)
+  "Default proxy used by dexador, Python-requests style. Either:
+ - NIL (no proxy),
+ - a proxy URL string (used for every scheme), or
+ - an alist mapping \"http\"/\"https\"/\"scheme://host\"/\"*\" (or \"all\") to proxy URLs.
+Defaults from the environment (https_proxy / http_proxy with an all_proxy fallback).
+Honors *NO-PROXY*. A proxy URL may carry credentials as user:pass@host and may use the
+socks5:// scheme.")
+
+(defvar *no-proxy* (getenv-nonempty "no_proxy" "NO_PROXY")
+  "Hosts that bypass the proxy (cf. NO_PROXY). A comma/space-separated string or a list of
+patterns. \"*\" bypasses every host. An IP host is compared against IP and CIDR patterns
+(e.g. \"127.0.0.1\", \"10.0.0.0/8\", \"::1\", \"fd00::/8\"); any other host matches a
+pattern exactly or as a domain suffix (a leading dot and any :port in a pattern are
+ignored). Defaults from the no_proxy / NO_PROXY environment variable.")
+
+(defun strip-ipv6-brackets (host)
+  "Return HOST without RFC 2732 brackets: \"[::1]\" or \"[::1]:8080\" -> \"::1\"."
+  (or (and (plusp (length host))
+           (char= (char host 0) #\[)
+           (let ((close (position #\] host)))
+             (and close (subseq host 1 close))))
+      host))
+
+(defun parse-ip-address (string)
+  "Parse STRING as an IPv4 or IPv6 literal (IPv6 may be bracketed).
+Returns (VALUES address-integer total-bits) with TOTAL-BITS 32 or 128, or NIL when
+STRING is not an IP literal."
+  (let ((string (strip-ipv6-brackets string)))
+    (if (find #\: string)
+        (let ((bytes (ignore-errors (ipv6-host-to-vector string))))
+          (when bytes
+            (values (reduce (lambda (acc byte) (logior (ash acc 8) byte))
+                            bytes :initial-value 0)
+                    128)))
+        (let ((parts (uiop:split-string string :separator ".")))
+          (when (= (length parts) 4)
+            (loop with address = 0
+                  for part in parts
+                  for byte = (and (<= 1 (length part) 3)
+                                  (every #'digit-char-p part)
+                                  (parse-integer part))
+                  unless (and byte (<= byte 255))
+                    do (return nil)
+                  do (setf address (logior (ash address 8) byte))
+                  finally (return (values address 32))))))))
+
+(defun ip-in-network-p (address total-bits pattern)
+  "True if the IP (ADDRESS integer of TOTAL-BITS) lies in the CIDR network PATTERN,
+e.g. \"10.0.0.0/8\" or \"2001:db8::/32\". Host bits set in PATTERN are masked off."
+  (let ((slash (position #\/ pattern)))
+    (when slash
+      (multiple-value-bind (network network-bits)
+          (parse-ip-address (subseq pattern 0 slash))
+        (let ((prefix (ignore-errors (parse-integer (subseq pattern (1+ slash))))))
+          (and network
+               (eql total-bits network-bits)
+               (integerp prefix)
+               (<= 0 prefix network-bits)
+               (= (ash address (- prefix network-bits))
+                  (ash network (- prefix network-bits)))))))))
+
+(defun ip-matches-pattern-p (address total-bits pattern)
+  "True if the IP (ADDRESS integer of TOTAL-BITS) matches PATTERN: a CIDR network, or an
+IP literal compared numerically (so \"::1\" matches \"0:0:0:0:0:0:0:1\"). A :port suffix
+is ignored on IPv4 and bracketed IPv6 patterns."
+  (if (find #\/ pattern)
+      (ip-in-network-p address total-bits pattern)
+      (multiple-value-bind (pattern-address pattern-bits)
+          (parse-ip-address
+           (let ((colon (position #\: pattern)))
+             (if (and colon (not (find #\: pattern :start (1+ colon))))
+                 (subseq pattern 0 colon) ; single colon: an IPv4 :port suffix
+                 pattern)))
+        (and pattern-address
+             (eql total-bits pattern-bits)
+             (= address pattern-address)))))
+
+(defun host-bypassed-p (host no-proxy)
+  "True if HOST should bypass the proxy according to NO-PROXY (NO_PROXY semantics).
+NO-PROXY is a comma/space-separated string or a list of patterns. \"*\" bypasses
+everything. An IP host matches IP/CIDR patterns; a hostname matches exactly or as a
+domain suffix."
+  (when (and host no-proxy)
+    (let ((host (strip-ipv6-brackets host))
+          (patterns (if (listp no-proxy)
+                        no-proxy
+                        (remove "" (mapcar (lambda (s) (string-trim '(#\Space #\Tab) s))
+                                           (uiop:split-string no-proxy :separator ", "))
+                                :test #'string=))))
+      (multiple-value-bind (address total-bits) (parse-ip-address host)
+        (some (lambda (raw)
+                (and (plusp (length raw))
+                     (or (string= raw "*")
+                         (if address
+                             (ip-matches-pattern-p address total-bits raw)
+                             ;; Drop a leading dot and any :port, e.g. ".example.com:443"
+                             ;; -> "example.com", then match exactly or as domain suffix.
+                             (let* ((dotless (string-left-trim "." raw))
+                                    (pattern (subseq dotless 0 (position #\: dotless))))
+                               (or (string-equal host pattern)
+                                   (let ((pl (length pattern)) (hl (length host)))
+                                     (and (plusp pl)
+                                          (> hl pl)
+                                          (char= (char host (- hl pl 1)) #\.)
+                                          (string-equal pattern (subseq host (- hl pl)))))))))))
+              patterns)))))
+
+(defun proxy-for-uri (uri proxy)
+  "Select the proxy URL for URI from PROXY (NIL, a URL string, or a scheme/host alist)."
+  (etypecase proxy
+    (null nil)
+    (string proxy)
+    (list
+     (let* ((scheme (uri-scheme uri))
+            (host (uri-host uri))
+            (host-key (and scheme host (format nil "~A://~A" scheme host))))
+       (cdr (or (and host-key (assoc host-key proxy :test #'string-equal))
+                (and scheme (assoc scheme proxy :test #'string-equal))
+                (assoc "*" proxy :test #'string-equal)
+                (assoc "all" proxy :test #'string-equal)))))))
+
+(defun resolve-proxy (uri proxy &optional (no-proxy *no-proxy*))
+  "Return the effective proxy URL string for URI, or NIL.
+PROXY is NIL, a URL string, or a scheme/host alist (see *DEFAULT-PROXY*). Returns NIL when
+URI's host matches NO-PROXY."
+  (let ((u (quri:uri uri)))
+    (unless (host-bypassed-p (uri-host u) no-proxy)
+      (proxy-for-uri u proxy))))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defvar *speedy-declaration* '(declare (optimize (speed 3) (safety 0) (space 0) (compilation-speed 0))))

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -88,6 +88,49 @@
         (ok (eql code 200))
         (ok (equal body (format nil "lisp.org~%/foo")))))))
 
+(deftest proxy-resolution-tests
+  (testing "per-scheme proxies alist (requests-style proxies dict)"
+    (let ((cfg '(("https" . "http://p-https:8080")
+                 ("http"  . "http://p-http:8080")
+                 ("https://special.example.com" . "http://p-host:9090")
+                 ("*"     . "http://p-all:1080"))))
+      (ok (equal (dexador.util:resolve-proxy "https://api.example.com/x" cfg) "http://p-https:8080"))
+      (ok (equal (dexador.util:resolve-proxy "http://api.example.com/x" cfg) "http://p-http:8080"))
+      (ok (equal (dexador.util:resolve-proxy "https://special.example.com/y" cfg) "http://p-host:9090")
+          "per-host key wins over per-scheme")
+      (ok (equal (dexador.util:resolve-proxy "ftp://files.example.com/z" cfg) "http://p-all:1080")
+          "falls back to \"*\"")))
+  (testing "string proxy applies to every scheme (backward compatible)"
+    (ok (equal (dexador.util:resolve-proxy "https://x.com/" "http://oneproxy:3128") "http://oneproxy:3128"))
+    (ok (null (dexador.util:resolve-proxy "https://x.com/" nil))))
+  (testing "NO_PROXY host matching (urllib/requests semantics)"
+    (ok (dexador.util:host-bypassed-p "example.com" "example.com"))
+    (ok (dexador.util:host-bypassed-p "api.example.com" ".example.com"))
+    (ok (dexador.util:host-bypassed-p "api.example.com" "example.com"))
+    (ng (dexador.util:host-bypassed-p "notexample.com" "example.com") "suffix must align on a dot")
+    (ok (dexador.util:host-bypassed-p "anything.net" "*") "\"*\" bypasses all")
+    (ok (dexador.util:host-bypassed-p "example.com" "example.com:443") ":port in pattern is ignored")
+    (ok (dexador.util:host-bypassed-p "a.foo.org" '("bar.com" ".foo.org")) "list form")
+    (ng (dexador.util:host-bypassed-p "a.foo.org" nil)))
+  (testing "NO_PROXY IP and CIDR matching (requests semantics, plus IPv6)"
+    (ok (dexador.util:host-bypassed-p "127.0.0.1" "127.0.0.1"))
+    (ok (dexador.util:host-bypassed-p "127.0.0.1" "127.0.0.1:8080") ":port on an IP pattern is ignored")
+    (ok (dexador.util:host-bypassed-p "10.1.2.3" "10.0.0.0/8"))
+    (ok (dexador.util:host-bypassed-p "192.168.1.7" "no-match.com, 192.168.0.0/16"))
+    (ng (dexador.util:host-bypassed-p "11.1.2.3" "10.0.0.0/8"))
+    (ng (dexador.util:host-bypassed-p "10.1.2.3" "example.com") "IP host never matches a hostname pattern")
+    (ng (dexador.util:host-bypassed-p "1.2.3.4" "2.3.4") "IP host requires IP/CIDR match, not a suffix")
+    (ok (dexador.util:host-bypassed-p "::1" "::1"))
+    (ok (dexador.util:host-bypassed-p "[::1]" "::1") "bracketed URL form of the host")
+    (ok (dexador.util:host-bypassed-p "::1" "0:0:0:0:0:0:0:1") "IPv6 compared numerically")
+    (ok (dexador.util:host-bypassed-p "fd12:3456::1" "fd00::/8"))
+    (ng (dexador.util:host-bypassed-p "2001:db8::1" "fd00::/8"))
+    (ng (dexador.util:host-bypassed-p "127.0.0.1" "::1") "no cross-family match"))
+  (testing "resolve-proxy honors no-proxy (bypass yields NIL)"
+    (let ((dexador.util:*no-proxy* "internal.example.com"))
+      (ok (null (dexador.util:resolve-proxy "https://internal.example.com/" "http://p:8080")))
+      (ok (equal (dexador.util:resolve-proxy "https://external.com/" "http://p:8080") "http://p:8080")))))
+
 (deftest proxy-socks5-tests
   #+windows
   (skip "SOCKS5 proxy tests are skipped")

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -100,9 +100,20 @@
           "per-host key wins over per-scheme")
       (ok (equal (dexador.util:resolve-proxy "ftp://files.example.com/z" cfg) "http://p-all:1080")
           "falls back to \"*\"")))
+  (testing "IPv6 per-host proxy keys (bare and bracketed)"
+    (let ((bare '(("https://::1" . "http://p-bare:1")
+                  ("https" . "http://p-https:1")))
+          (bracketed '(("https://[::1]" . "http://p-bracket:1")
+                       ("https" . "http://p-https:1"))))
+      (ok (equal (dexador.util:resolve-proxy "https://[::1]/" bare) "http://p-bare:1")
+          "bare scheme://host key matches bracketed URI host")
+      (ok (equal (dexador.util:resolve-proxy "https://[::1]/" bracketed) "http://p-bracket:1")
+          "bracketed scheme://host key matches")))
   (testing "string proxy applies to every scheme (backward compatible)"
     (ok (equal (dexador.util:resolve-proxy "https://x.com/" "http://oneproxy:3128") "http://oneproxy:3128"))
-    (ok (null (dexador.util:resolve-proxy "https://x.com/" nil))))
+    (ok (null (dexador.util:resolve-proxy "https://x.com/" nil)))
+    (ok (null (dexador.util:resolve-proxy "https://x.com/" '(("http" . "http://p:1"))))
+        "unmatched scheme yields NIL, not an error"))
   (testing "NO_PROXY host matching"
     (ok (dexador.util:host-bypassed-p "example.com" "example.com"))
     (ok (dexador.util:host-bypassed-p "api.example.com" ".example.com"))

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -89,6 +89,19 @@
         (ok (equal body (format nil "lisp.org~%/foo")))))))
 
 (deftest proxy-resolution-tests
+  (testing "single environment proxy remains a fallback for both schemes"
+    (let ((http-only (dexador.util::make-environment-proxy nil "http://p-http:8080" nil))
+          (https-only (dexador.util::make-environment-proxy "http://p-https:8080" nil nil))
+          (http-and-all (dexador.util::make-environment-proxy
+                         nil "http://p-http:8080" "http://p-all:1080")))
+      (ok (equal (dexador.util:resolve-proxy "https://example.com/" http-only)
+                 "http://p-http:8080"))
+      (ok (equal (dexador.util:resolve-proxy "http://example.com/" https-only)
+                 "http://p-https:8080"))
+      (ok (equal (dexador.util:resolve-proxy "http://example.com/" http-and-all)
+                 "http://p-http:8080"))
+      (ok (equal (dexador.util:resolve-proxy "https://example.com/" http-and-all)
+                 "http://p-all:1080"))))
   (testing "per-scheme proxy alist"
     (let ((cfg '(("https" . "http://p-https:8080")
                  ("http"  . "http://p-http:8080")

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -89,7 +89,7 @@
         (ok (equal body (format nil "lisp.org~%/foo")))))))
 
 (deftest proxy-resolution-tests
-  (testing "per-scheme proxies alist (requests-style proxies dict)"
+  (testing "per-scheme proxy alist"
     (let ((cfg '(("https" . "http://p-https:8080")
                  ("http"  . "http://p-http:8080")
                  ("https://special.example.com" . "http://p-host:9090")
@@ -103,7 +103,7 @@
   (testing "string proxy applies to every scheme (backward compatible)"
     (ok (equal (dexador.util:resolve-proxy "https://x.com/" "http://oneproxy:3128") "http://oneproxy:3128"))
     (ok (null (dexador.util:resolve-proxy "https://x.com/" nil))))
-  (testing "NO_PROXY host matching (urllib/requests semantics)"
+  (testing "NO_PROXY host matching"
     (ok (dexador.util:host-bypassed-p "example.com" "example.com"))
     (ok (dexador.util:host-bypassed-p "api.example.com" ".example.com"))
     (ok (dexador.util:host-bypassed-p "api.example.com" "example.com"))
@@ -112,7 +112,7 @@
     (ok (dexador.util:host-bypassed-p "example.com" "example.com:443") ":port in pattern is ignored")
     (ok (dexador.util:host-bypassed-p "a.foo.org" '("bar.com" ".foo.org")) "list form")
     (ng (dexador.util:host-bypassed-p "a.foo.org" nil)))
-  (testing "NO_PROXY IP and CIDR matching (requests semantics, plus IPv6)"
+  (testing "NO_PROXY IP and CIDR matching"
     (ok (dexador.util:host-bypassed-p "127.0.0.1" "127.0.0.1"))
     (ok (dexador.util:host-bypassed-p "127.0.0.1" "127.0.0.1:8080") ":port on an IP pattern is ignored")
     (ok (dexador.util:host-bypassed-p "10.1.2.3" "10.0.0.0/8"))

--- a/t/dexador.lisp
+++ b/t/dexador.lisp
@@ -11,18 +11,36 @@
 
 (defun random-port ()
   "Return a port number not in use from 50000 to 60000."
+  ;; IGNORE-ERRORS: binding can fail with errors clack.test doesn't handle,
+  ;; e.g. WSAEACCES when the port is in a Windows excluded port range (Hyper-V).
   (loop for port from (+ 50000 (random 1000)) upto 60000
-        if (clack.test::port-available-p port)
+        if (ignore-errors (port-available-p port))
           return port))
 
 (defmacro testing-app ((desc &key use-connection-pool) app &body body)
-  `(let ((*clack-test-port* (random-port)))
+  ;; Disable clack.test's own port picking: its PORT-AVAILABLE-P chokes on
+  ;; Windows excluded port ranges, so choose the port with ours instead.
+  `(let* ((clack.test:*random-port* nil)
+          (*clack-test-port* (random-port))
+          (clack.test:*clack-test-access-port* *clack-test-port*))
      (clack.test:testing-app ,desc ,app
        ;; Clack's TESTING-APP sets dex:*use-connection-pool* to NIL,
        ;; but we need to change it in some tests
        (let ((dex:*use-connection-pool* ,use-connection-pool))
          (dex:clear-connection-pool)
          ,@body))))
+
+(defmacro with-proxy-capable-backend (() &body body)
+  "Run BODY with a proxy-testable backend. These tests proxy to loopback
+origins, which WinHTTP always bypasses, so use usocket on Windows.
+The winhttp backend is covered by dexador-integration-test instead."
+  #-windows `(progn ,@body)
+  #+windows `(let ((dex:*dexador-backend* :usocket))
+               ,@body))
+
+(defun proxied-by (headers)
+  "Which test proxy served the response, or NIL when it was direct."
+  (gethash dexador-test.proxy:+proxied-by-header+ headers))
 
 (deftest normal-case-tests
   (testing-app ("normal case")
@@ -52,41 +70,143 @@
         (ok (equal body "/foo"))))))
 
 (deftest proxy-http-tests
-  #+windows
-  (skip "Skipped proxy tests on Windows")
+  (with-proxy-capable-backend ()
+    (testing-app ("proxy (http) case")
+        (lambda (env)
+          (let ((body (format nil "~A~%~A"
+                              (gethash "host" (getf env :headers))
+                              (getf env :request-uri))))
+            `(200 (:content-length ,(length body)) (,body))))
+      (dexador-test.proxy:with-test-proxy (proxy)
+        (let ((proxy-url (dexador-test.proxy:test-proxy-url proxy))
+              (expected (format nil "~A~%/foo"
+                                (quri:uri-authority (quri:uri (localhost))))))
+          (testing "GET"
+            (multiple-value-bind (body code headers)
+                (dex:get (localhost "/foo")
+                         :headers '((:x-foo . "ppp"))
+                         :proxy proxy-url)
+              (ok (eql code 200))
+              (ok (equal body expected))
+              (ok (equal (proxied-by headers) "cl-test-proxy"))))
+          (testing "HEAD"
+            (multiple-value-bind (body code headers)
+                (dex:head (localhost "/foo") :proxy proxy-url)
+              (ok (eql code 200))
+              (ok (equal body ""))
+              (ok (equal (proxied-by headers) "cl-test-proxy"))))
+          (testing "PUT"
+            (multiple-value-bind (body code headers)
+                (dex:put (localhost "/foo") :proxy proxy-url)
+              (ok (eql code 200))
+              (ok (equal body expected))
+              (ok (equal (proxied-by headers) "cl-test-proxy"))))
+          (testing "DELETE"
+            (multiple-value-bind (body code headers)
+                (dex:delete (localhost "/foo") :proxy proxy-url)
+              (ok (eql code 200))
+              (ok (equal body expected))
+              (ok (equal (proxied-by headers) "cl-test-proxy"))))
+          (testing "the proxy received absolute-form request targets"
+            (ok (every (lambda (line)
+                         (search " http://" line))
+                       (dexador-test.proxy:test-proxy-requests proxy)))))))))
+
+(deftest proxy-auth-tests
+  (with-proxy-capable-backend ()
+    (testing-app ("proxy (Basic auth) case")
+        (lambda (env)
+          (declare (ignore env))
+          '(200 (:content-length 2) ("OK")))
+      (dexador-test.proxy:with-test-proxy (proxy :basic-auth '("proxyuser" . "proxypass"))
+        (testing "no credentials -> 407"
+          (handler-case
+              (progn (dex:get (localhost "/") :proxy (dexador-test.proxy:test-proxy-url proxy))
+                     (fail "Expected HTTP-REQUEST-PROXY-AUTHENTICATION-REQUIRED"))
+            (dex:http-request-proxy-authentication-required (e)
+              (ok (eql (dex:response-status e) 407)))))
+        (testing "wrong credentials -> 407"
+          (handler-case
+              (progn (dex:get (localhost "/")
+                              :proxy (dexador-test.proxy:test-proxy-url proxy :userinfo "proxyuser:wrong"))
+                     (fail "Expected HTTP-REQUEST-PROXY-AUTHENTICATION-REQUIRED"))
+            (dex:http-request-proxy-authentication-required (e)
+              (ok (eql (dex:response-status e) 407)))))
+        (testing "user:pass@host proxy URL sends Proxy-Authorization"
+          (multiple-value-bind (body code headers)
+              (dex:get (localhost "/")
+                       :proxy (dexador-test.proxy:test-proxy-url proxy :userinfo "proxyuser:proxypass"))
+            (ok (eql code 200))
+            (ok (equal body "OK"))
+            (ok (equal (proxied-by headers) "cl-test-proxy"))))))))
+
+(deftest proxy-bypass-tests
+  (with-proxy-capable-backend ()
+    (testing-app ("proxy bypass (*no-proxy*) case")
+        (lambda (env)
+          (declare (ignore env))
+          '(200 (:content-length 2) ("OK")))
+      (dexador-test.proxy:with-test-proxy (proxy)
+        (let ((dex:*default-proxy* (dexador-test.proxy:test-proxy-url proxy)))
+          (testing "*default-proxy* routes through the proxy"
+            (multiple-value-bind (body code headers) (dex:get (localhost "/"))
+              (declare (ignore body))
+              (ok (eql code 200))
+              (ok (equal (proxied-by headers) "cl-test-proxy"))))
+          (testing "*no-proxy* pattern bypasses the proxy"
+            (let ((dex:*no-proxy* "127.0.0.0/8,localhost"))
+              (multiple-value-bind (body code headers) (dex:get (localhost "/"))
+                (declare (ignore body))
+                (ok (eql code 200))
+                (ok (null (proxied-by headers)))))))))))
+
+(deftest winhttp-ntlm-auth-tests
   #-windows
-  (testing-app ("proxy (http) case")
-      ; proxy behavior is same as direct connection if http
-      (lambda (env)
-        (let ((body (format nil "~A~%~A"
-                            (gethash "host" (getf env :headers))
-                            (getf env :request-uri))))
-          `(200 (:content-length ,(length body)) (,body))))
-    (testing "GET"
-      (multiple-value-bind (body code)
-          (dex:get "http://lisp.org/foo"
-                   :headers '((:x-foo . "ppp"))
-                   :proxy (localhost))
-        (ok (eql code 200))
-        (ok (equal body (format nil "lisp.org~%/foo")))))
-    (testing "HEAD"
-      (multiple-value-bind (body code)
-          (dex:head "http://lisp.org/foo"
-                    :proxy (localhost))
-        (ok (eql code 200))
-        (ok (equal body ""))))
-    (testing "PUT"
-      (multiple-value-bind (body code)
-          (dex:put "http://lisp.org/foo"
-                   :proxy (localhost))
-        (ok (eql code 200))
-        (ok (equal body (format nil "lisp.org~%/foo")))))
-    (testing "DELETE"
-      (multiple-value-bind (body code)
-          (dex:delete "http://lisp.org/foo"
-                      :proxy (localhost))
-        (ok (eql code 200))
-        (ok (equal body (format nil "lisp.org~%/foo")))))))
+  (skip "NTLM authentication tests target the winhttp backend (Windows only)")
+  #+windows
+  (let ((dex:*dexador-backend* :winhttp))
+    (flet ((url (server)
+             (format nil "http://127.0.0.1:~D/" (dexador-test.ntlm:ntlm-server-port server))))
+      (testing "the strongest authentication scheme is selected"
+        (ok (eq (dexador.backend.winhttp::select-auth-scheme-from-mask
+                 (logior dexador.backend.winhttp::+WINHTTP_AUTH_SCHEME_BASIC+
+                         dexador.backend.winhttp::+WINHTTP_AUTH_SCHEME_NTLM+))
+                :ntlm)))
+      (testing "autologon defaults to the intranet zone"
+        (ok (= (dexador.backend.winhttp::autologon-policy-value)
+               dexador.backend.winhttp::+WINHTTP_AUTOLOGON_SECURITY_LEVEL_MEDIUM+)))
+      (testing "explicit NTLM credentials complete the challenge/resend handshake"
+        (dexador-test.ntlm:with-ntlm-server (server)
+          (multiple-value-bind (body code)
+              (dex:get (url server) :basic-auth (cons "user" "pass") :force-string t)
+            (ok (eql code 200))
+            (ok (equal body "SSO-OK"))
+            ;; Full handshake over one kept-alive connection: Type 1 then Type 3.
+            (ok (equal (dexador-test.ntlm:ntlm-server-message-types server) '(1 3))))))
+      (testing "single sign-on engages NTLM with the logged-on credentials"
+        (dexador-test.ntlm:with-ntlm-server (server)
+          ;; :LOW is required here because the stub listens on an IP address;
+          ;; the default :MEDIUM policy only releases credentials to intranet
+          ;; zone *names*. Production code should keep :MEDIUM.
+          (let ((dex:*winhttp-autologon-policy* :low))
+            ;; The loopback logon token can't finish NTLM against a 127.0.0.1 fake,
+            ;; but the client must at least offer NTLM (a Type 1) using default
+            ;; credentials -- that is the single-sign-on path being exercised.
+            (ignore-errors (dex:get (url server)))
+            (ok (member 1 (dexador-test.ntlm:ntlm-server-message-types server))))))
+      (testing "*use-default-credentials* nil leaves the challenge unanswered"
+        (dexador-test.ntlm:with-ntlm-server (server)
+          (let ((dex:*use-default-credentials* nil))
+            (handler-case
+                (progn (dex:get (url server))
+                       (fail "Expected HTTP-REQUEST-UNAUTHORIZED"))
+              (dex:http-request-unauthorized (e)
+                (ok (eql (dex:response-status e) 401)))))
+          ;; The handshake never completes: the server never sees a Type 3.
+          ;; (WinHTTP still auto-emits a Type 1 for loopback/IP hosts, where the
+          ;; autologon HIGH policy is documented not to take effect, so we can't
+          ;; assert the server saw nothing at all.)
+          (ok (not (member 3 (dexador-test.ntlm:ntlm-server-message-types server)))))))))
 
 (deftest proxy-resolution-tests
   (testing "single environment proxy remains a fallback for both schemes"
@@ -122,6 +242,18 @@
           "bare scheme://host key matches bracketed URI host")
       (ok (equal (dexador.util:resolve-proxy "https://[::1]/" bracketed) "http://p-bracket:1")
           "bracketed scheme://host key matches")))
+  (testing "format-host-port brackets IPv6"
+    (ok (equal (dexador.util:format-host-port "example.com" 8080) "example.com:8080"))
+    (ok (equal (dexador.util:format-host-port "::1" 8080) "[::1]:8080"))
+    (ok (equal (dexador.util:format-host-port "[::1]" 8080) "[::1]:8080")))
+  (testing "absolute-form request target omits userinfo"
+    (let ((line (babel:octets-to-string
+                 (fast-io:with-fast-output (buffer)
+                   (dexador.util:write-first-line
+                    :get (quri:uri "http://user:pass@example.com/path?q=1#fragment")
+                    1.1 buffer t)))))
+      (ok (equal line (format nil "GET http://example.com/path?q=1 HTTP/1.1~C~C"
+                              #\Return #\Newline)))))
   (testing "string proxy applies to every scheme (backward compatible)"
     (ok (equal (dexador.util:resolve-proxy "https://x.com/" "http://oneproxy:3128") "http://oneproxy:3128"))
     (ok (null (dexador.util:resolve-proxy "https://x.com/" nil)))

--- a/t/integration.lisp
+++ b/t/integration.lisp
@@ -1,0 +1,362 @@
+(in-package :cl-user)
+(defpackage dexador-integration-test
+  (:use :cl
+        :rove)
+  (:import-from :clack.test
+                :*clack-test-port*
+                :localhost))
+(in-package :dexador-integration-test)
+
+;;; Integration tests that route requests through a real external proxy.
+;;;
+;;; The proxies are started outside the suite (see .github/workflows/ci.yml,
+;;; which runs mitmproxy). Any RFC-compliant HTTP proxy works: traversal is
+;;; detected through the Via header that proxies MUST add to forwarded
+;;; requests (RFC 9110 section 7.6.3), echoed back by the test origin.
+;;; mitmproxy needs .github/mitmproxy-addon.py to add Via.
+;;;
+;;; Expected environment:
+;;;   DEXADOR_TEST_PROXY        e.g. http://127.0.0.1:3128 (no auth)
+;;;   DEXADOR_TEST_AUTH_PROXY   e.g. http://127.0.0.1:3129 (Basic dexador:test)
+;;;   DEXADOR_TEST_SOCKS5_PROXY e.g. socks5://127.0.0.1:3130
+;;; Tests are skipped when none of these are set.
+;;;
+;;; HTTPS-through-proxy tests additionally need DEXADOR_TEST_PROXY_CA: the
+;;; path to the proxy's self-signed CA certificate (mitmproxy's
+;;; ~/.mitmproxy/mitmproxy-ca-cert.pem). The proxy terminates TLS with certs
+;;; signed by that CA and forwards to the plain-HTTP origin (the addon
+;;; downgrades the upstream hop; run mitmproxy with upstream_cert=false and
+;;; connection_strategy=lazy). On Windows the CA must also be imported into
+;;; the certificate store for the winhttp backend:
+;;;   certutil -addstore Root %USERPROFILE%\.mitmproxy\mitmproxy-ca-cert.cer
+
+(defun random-port ()
+  ;; IGNORE-ERRORS: binding can fail with errors clack.test doesn't handle,
+  ;; e.g. WSAEACCES when the port is in a Windows excluded port range.
+  (loop for port from (+ 50000 (random 1000)) upto 60000
+        if (ignore-errors (clack.test::port-available-p port))
+          return port))
+
+(defmacro testing-app ((desc) app &body body)
+  ;; Disable clack.test's own port picking; see RANDOM-PORT above.
+  `(let* ((clack.test:*random-port* nil)
+          (*clack-test-port* (random-port))
+          (clack.test:*clack-test-access-port* *clack-test-port*))
+     (clack.test:testing-app ,desc ,app
+       (let ((dex:*use-connection-pool* nil))
+         (dex:clear-connection-pool)
+         ,@body))))
+
+(defmacro with-proxy-capable-backend (() &body body)
+  "Use the usocket backend on Windows: these tests reach the origin via
+127.0.0.1 and WinHTTP never proxies loopback addresses. The winhttp
+backend has its own tests below against a routable origin address."
+  #-windows `(progn ,@body)
+  #+windows `(let ((dex:*dexador-backend* :usocket))
+               ,@body))
+
+(defun env-url (name)
+  (let ((value (uiop:getenv name)))
+    (and value (plusp (length value)) value)))
+
+(defun url-with-userinfo (url userinfo)
+  (let ((uri (quri:uri url)))
+    (setf (quri:uri-userinfo uri) userinfo)
+    (quri:render-uri uri)))
+
+(defparameter *echo-via-app*
+  (lambda (env)
+    ;; Body is "<request-uri>|<via header or empty>", so the client can see
+    ;; both what path arrived and whether a proxy forwarded the request.
+    (let ((body (format nil "~A|~A"
+                        (getf env :request-uri)
+                        (or (gethash "via" (getf env :headers)) ""))))
+      `(200 (:content-length ,(length body)) (,body)))))
+
+(defun get-via (uri &rest args)
+  "GET through dexador; return (VALUES status path via-header)."
+  (multiple-value-bind (body code) (apply #'dex:get uri args)
+    (let ((bar (position #\| body)))
+      (values code (subseq body 0 bar) (subseq body (1+ bar))))))
+
+(deftest external-proxy-integration
+  (let ((proxy-url (env-url "DEXADOR_TEST_PROXY"))
+        (auth-proxy-url (env-url "DEXADOR_TEST_AUTH_PROXY"))
+        (socks5-url (env-url "DEXADOR_TEST_SOCKS5_PROXY")))
+    (if (not (or proxy-url auth-proxy-url socks5-url))
+        (skip "Set DEXADOR_TEST_PROXY (and friends) to run external proxy integration tests")
+        (with-proxy-capable-backend ()
+          (testing-app ("external proxy integration") *echo-via-app*
+            (testing "direct request carries no Via header"
+              (multiple-value-bind (code path via) (get-via (localhost "/direct"))
+                (ok (eql code 200))
+                (ok (equal path "/direct"))
+                (ok (zerop (length via)))))
+            (when proxy-url
+              (testing "plain forward proxy adds Via to the forwarded request"
+                (multiple-value-bind (code path via)
+                    (get-via (localhost "/via-proxy") :proxy proxy-url)
+                  (ok (eql code 200))
+                  (ok (equal path "/via-proxy"))
+                  (ok (plusp (length via))))))
+            (when auth-proxy-url
+              (testing "auth proxy without credentials -> 407"
+                (handler-case
+                    (progn (dex:get (localhost "/secret") :proxy auth-proxy-url)
+                           (fail "Expected HTTP-REQUEST-PROXY-AUTHENTICATION-REQUIRED"))
+                  (dex:http-request-proxy-authentication-required (e)
+                    (ok (eql (dex:response-status e) 407)))))
+              (testing "auth proxy with credentials"
+                (multiple-value-bind (code path via)
+                    (get-via (localhost "/secret")
+                             :proxy (url-with-userinfo auth-proxy-url "dexador:test"))
+                  (ok (eql code 200))
+                  (ok (equal path "/secret"))
+                  (ok (plusp (length via))))))
+            (when socks5-url
+              ;; A SOCKS5 proxy is layer-4 and never touches HTTP headers, so
+              ;; only reachability is asserted. (mitmproxy in socks5 mode is
+              ;; HTTP-aware and does add Via, but a pure SOCKS proxy won't.)
+              (testing "socks5 proxy"
+                (multiple-value-bind (code path via)
+                    (get-via (localhost "/via-socks5") :proxy socks5-url)
+                  (declare (ignore via))
+                  (ok (eql code 200))
+                  (ok (equal path "/via-socks5"))))))))))
+
+(deftest https-proxy-integration
+  (let ((proxy-url (env-url "DEXADOR_TEST_PROXY"))
+        (auth-proxy-url (env-url "DEXADOR_TEST_AUTH_PROXY"))
+        (ca-file (env-url "DEXADOR_TEST_PROXY_CA")))
+    (cond
+      ((not ca-file)
+       (skip "Set DEXADOR_TEST_PROXY_CA (the proxy's CA certificate) to run HTTPS proxy tests"))
+      ((not (or proxy-url auth-proxy-url))
+       (skip "Set DEXADOR_TEST_PROXY / DEXADOR_TEST_AUTH_PROXY to run HTTPS proxy tests"))
+      ((member :dexador-no-ssl *features*)
+       (skip "SSL support is disabled (:dexador-no-ssl)"))
+      (t
+       (with-proxy-capable-backend ()
+         (testing-app ("https through proxy (usocket)") *echo-via-app*
+           ;; "localhost" (not 127.0.0.1) so the MITM certificate carries a
+           ;; DNS SAN and standard hostname verification applies.
+           (flet ((https-url (path)
+                    (format nil "https://localhost:~D~A" *clack-test-port* path)))
+             (when proxy-url
+               (testing "CONNECT tunnel with verified certificate"
+                 (multiple-value-bind (code path via)
+                     (get-via (https-url "/https-proxy") :proxy proxy-url :ca-path ca-file)
+                   (ok (eql code 200))
+                   (ok (equal path "/https-proxy"))
+                   (ok (plusp (length via))))))
+             (when auth-proxy-url
+               (testing "authenticated CONNECT"
+                 (multiple-value-bind (code path via)
+                     (get-via (https-url "/https-auth")
+                              :proxy (url-with-userinfo auth-proxy-url "dexador:test")
+                              :ca-path ca-file)
+                   (ok (eql code 200))
+                   (ok (equal path "/https-auth"))
+                   (ok (plusp (length via)))))))))))))
+
+;;; WinHTTP backend proxy tests (Windows only).
+;;;
+;;; WinHTTP never proxies requests to loopback addresses, so the test origin
+;;; must be reached through a routable address of this machine, given via
+;;; DEXADOR_TEST_ORIGIN_HOST (e.g. the runner's LAN IP). The origin is bound
+;;; to all interfaces for these tests.
+
+#+windows
+(progn
+
+(defun origin-host ()
+  (env-url "DEXADOR_TEST_ORIGIN_HOST"))
+
+(defun origin (path)
+  (format nil "http://~A:~D~A" (origin-host) *clack-test-port* path))
+
+(defmacro testing-app-all-interfaces ((desc) app &body body)
+  `(let ((clack.test:*clackup-additional-args* '(:address "0.0.0.0")))
+     (testing-app (,desc) ,app ,@body)))
+
+(deftest winhttp-explicit-proxy
+  (let ((proxy-url (env-url "DEXADOR_TEST_PROXY"))
+        (auth-proxy-url (env-url "DEXADOR_TEST_AUTH_PROXY")))
+    (cond
+      ((not (origin-host))
+       (skip "Set DEXADOR_TEST_ORIGIN_HOST (a non-loopback address of this machine) to test the winhttp backend"))
+      ((not (or proxy-url auth-proxy-url))
+       (skip "Set DEXADOR_TEST_PROXY / DEXADOR_TEST_AUTH_PROXY to test the winhttp backend"))
+      (t
+       (let ((dex:*dexador-backend* :winhttp)
+             ;; Make the direct case deterministic even if the machine has a system proxy.
+             (dex:*use-system-proxy* nil))
+         (testing-app-all-interfaces ("winhttp explicit proxy") *echo-via-app*
+           (testing "direct request carries no Via header"
+             (multiple-value-bind (code path via) (get-via (origin "/direct"))
+               (ok (eql code 200))
+               (ok (equal path "/direct"))
+               (ok (zerop (length via)))))
+           (when proxy-url
+             (testing "plain forward proxy adds Via to the forwarded request"
+               (multiple-value-bind (code path via)
+                   (get-via (origin "/via-proxy") :proxy proxy-url)
+                 (ok (eql code 200))
+                 (ok (equal path "/via-proxy"))
+                 (ok (plusp (length via)))))
+             (testing "*no-proxy* bypasses the proxy"
+               (let ((dex:*no-proxy* (origin-host)))
+                 (multiple-value-bind (code path via)
+                     (get-via (origin "/bypass") :proxy proxy-url)
+                   (ok (eql code 200))
+                   (ok (equal path "/bypass"))
+                   (ok (zerop (length via)))))))
+           (when auth-proxy-url
+             (testing "auth proxy without credentials -> 407"
+               (handler-case
+                   (progn (dex:get (origin "/secret") :proxy auth-proxy-url)
+                          (fail "Expected HTTP-REQUEST-PROXY-AUTHENTICATION-REQUIRED"))
+                 (dex:http-request-proxy-authentication-required (e)
+                   (ok (eql (dex:response-status e) 407)))))
+             (testing "auth proxy with credentials"
+               (multiple-value-bind (code path via)
+                   (get-via (origin "/secret")
+                            :proxy (url-with-userinfo auth-proxy-url "dexador:test"))
+                 (ok (eql code 200))
+                 (ok (equal path "/secret"))
+                 (ok (plusp (length via))))))
+           (testing "socks5 proxy is rejected"
+             (ok (signals (dex:get (origin "/socks") :proxy "socks5://127.0.0.1:1080")
+                          'error)))))))))
+
+(deftest winhttp-https-proxy
+  (let ((proxy-url (env-url "DEXADOR_TEST_PROXY"))
+        (auth-proxy-url (env-url "DEXADOR_TEST_AUTH_PROXY")))
+    (cond
+      ((not (env-url "DEXADOR_TEST_PROXY_CA"))
+       ;; WinHTTP validates against the Windows certificate store; the CA env
+       ;; var doubles as the signal that the proxy CA has been imported there.
+       (skip "Set DEXADOR_TEST_PROXY_CA (and certutil -addstore Root it) to run winhttp HTTPS proxy tests"))
+      ((not (origin-host))
+       (skip "Set DEXADOR_TEST_ORIGIN_HOST (a non-loopback address of this machine) to test the winhttp backend"))
+      ((not (or proxy-url auth-proxy-url))
+       (skip "Set DEXADOR_TEST_PROXY / DEXADOR_TEST_AUTH_PROXY to run HTTPS proxy tests"))
+      (t
+       (let ((dex:*dexador-backend* :winhttp)
+             (dex:*use-system-proxy* nil))
+         (testing-app-all-interfaces ("winhttp https through proxy") *echo-via-app*
+           ;; The MITM certificate carries the origin IP as a SAN; WinHTTP
+           ;; verifies IP SANs against the request host.
+           (flet ((https-url (path)
+                    (format nil "https://~A:~D~A" (origin-host) *clack-test-port* path)))
+             (when proxy-url
+               (testing "CONNECT tunnel with verified certificate"
+                 (multiple-value-bind (code path via)
+                     (get-via (https-url "/https-proxy") :proxy proxy-url)
+                   (ok (eql code 200))
+                   (ok (equal path "/https-proxy"))
+                   (ok (plusp (length via))))))
+             (when auth-proxy-url
+               (testing "authenticated CONNECT (Basic credentials on 407 challenge)"
+                 (multiple-value-bind (code path via)
+                     (get-via (https-url "/https-auth")
+                              :proxy (url-with-userinfo auth-proxy-url "dexador:test"))
+                   (ok (eql code 200))
+                   (ok (equal path "/https-auth"))
+                   (ok (plusp (length via)))))))))))))
+
+;;; System proxy discovery: these tests rewrite the current user's WinINet
+;;; proxy settings in the registry (Internet Options), which is what
+;;; *use-system-proxy* discovery reads. Settings are saved and restored, but
+;;; the tests still only run when DEXADOR_TEST_MUTATE_SYSTEM_PROXY=1 --
+;;; meant for disposable CI runners.
+
+(defparameter +inet-settings-key+
+  "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings")
+
+(defun reg-set (name type value)
+  (uiop:run-program (list "reg" "add" +inet-settings-key+
+                          "/v" name "/t" type "/d" (princ-to-string value) "/f")
+                    :output nil :error-output nil))
+
+(defun reg-delete (name)
+  (uiop:run-program (list "reg" "delete" +inet-settings-key+ "/v" name "/f")
+                    :output nil :error-output nil :ignore-error-status t))
+
+(defun reg-query (name)
+  "Return (VALUES value type) for NAME under the Internet Settings key, or NIL."
+  (let* ((out (uiop:run-program (list "reg" "query" +inet-settings-key+ "/v" name)
+                                :output :string :error-output nil :ignore-error-status t))
+         ;; "    ProxyServer    REG_SZ    127.0.0.1:3128"
+         (line (find-if (lambda (l) (search name l)) (uiop:split-string out :separator '(#\Newline))))
+         (parts (and line (remove "" (uiop:split-string (string-trim '(#\Return) line))
+                                  :test #'string=))))
+    (when (and parts (<= 3 (length parts)))
+      (values (format nil "~{~A~^ ~}" (cddr parts)) (second parts)))))
+
+(defun call-with-saved-proxy-registry (fn)
+  (let ((saved (loop for name in '("ProxyEnable" "ProxyServer" "AutoConfigURL")
+                     collect (multiple-value-bind (value type) (reg-query name)
+                               (list name value type)))))
+    (unwind-protect (funcall fn)
+      (loop for (name value type) in saved
+            do (if value
+                   (reg-set name type value)
+                   (reg-delete name))))))
+
+(defun make-pac-app (proxy-hostport)
+  "Like *ECHO-VIA-APP* but also serves a PAC script routing everything through PROXY-HOSTPORT."
+  (lambda (env)
+    (if (string= (getf env :path-info) "/proxy.pac")
+        (let ((pac (format nil "function FindProxyForURL(url, host) { return \"PROXY ~A\"; }"
+                           proxy-hostport)))
+          `(200 (:content-type "application/x-ns-proxy-autoconfig"
+                 :content-length ,(length pac))
+                (,pac)))
+        (funcall *echo-via-app* env))))
+
+(deftest winhttp-system-proxy-discovery
+  (let ((proxy-url (env-url "DEXADOR_TEST_PROXY")))
+    (cond
+      ((not (equal (uiop:getenv "DEXADOR_TEST_MUTATE_SYSTEM_PROXY") "1"))
+       (skip "Set DEXADOR_TEST_MUTATE_SYSTEM_PROXY=1 to run tests that rewrite the user's registry proxy settings"))
+      ((not (and (origin-host) proxy-url))
+       (skip "Also requires DEXADOR_TEST_ORIGIN_HOST and DEXADOR_TEST_PROXY"))
+      (t
+       (let* ((dex:*dexador-backend* :winhttp)
+              (proxy-uri (quri:uri proxy-url))
+              (proxy-hostport (format nil "~A:~D"
+                                      (quri:uri-host proxy-uri) (quri:uri-port proxy-uri))))
+         (call-with-saved-proxy-registry
+          (lambda ()
+            (testing-app-all-interfaces ("winhttp system proxy discovery") (make-pac-app proxy-hostport)
+              (testing "static registry proxy (Internet Options) is discovered"
+                (reg-set "ProxyEnable" "REG_DWORD" 1)
+                (reg-set "ProxyServer" "REG_SZ" proxy-hostport)
+                (reg-delete "AutoConfigURL")
+                (multiple-value-bind (code path via) (get-via (origin "/registry"))
+                  (ok (eql code 200))
+                  (ok (equal path "/registry"))
+                  (ok (plusp (length via)))))
+              (testing "*use-system-proxy* nil connects directly"
+                (let ((dex:*use-system-proxy* nil))
+                  (multiple-value-bind (code path via) (get-via (origin "/registry-off"))
+                    (ok (eql code 200))
+                    (ok (equal path "/registry-off"))
+                    (ok (zerop (length via))))))
+              (testing "*no-proxy* wins over system settings"
+                (let ((dex:*no-proxy* (origin-host)))
+                  (multiple-value-bind (code path via) (get-via (origin "/registry-bypass"))
+                    (ok (eql code 200))
+                    (ok (equal path "/registry-bypass"))
+                    (ok (zerop (length via))))))
+              (testing "PAC script (AutoConfigURL) is evaluated"
+                (reg-set "ProxyEnable" "REG_DWORD" 0)
+                (reg-delete "ProxyServer")
+                (reg-set "AutoConfigURL" "REG_SZ" (origin "/proxy.pac"))
+                (multiple-value-bind (code path via) (get-via (origin "/pac"))
+                  (ok (eql code 200))
+                  (ok (equal path "/pac"))
+                  (ok (plusp (length via)))))))))))))
+
+) ; #+windows progn

--- a/t/ntlm-server.lisp
+++ b/t/ntlm-server.lisp
@@ -1,0 +1,144 @@
+(in-package :cl-user)
+(defpackage #:dexador-test.ntlm
+  (:use #:cl)
+  (:import-from #:cl-base64
+                #:usb8-array-to-base64-string
+                #:base64-string-to-usb8-array)
+  (:export #:start-ntlm-server
+           #:stop-ntlm-server
+           #:ntlm-server-port
+           #:ntlm-server-message-types
+           #:with-ntlm-server))
+(in-package #:dexador-test.ntlm)
+
+;;; A fake NTLM-authenticating HTTP server for exercising the winhttp
+;;; backend's single-sign-on challenge loop against a real SSPI client.
+;;;
+;;; It performs the NTLM handshake structurally without validating any
+;;; cryptography: 401 + "WWW-Authenticate: NTLM" on unauthenticated requests,
+;;; a static Type 2 challenge in reply to the client's Type 1 token, and
+;;; 200 "SSO-OK" for the final Type 3 token. NTLM is connection-oriented, so
+;;; all three legs are served over one kept-alive connection.
+
+(defun type2-challenge-message ()
+  "The canonical CHALLENGE_MESSAGE (Type 2) test vector from MS-NLMP 4.2.4.3.
+Using the spec's own bytes guarantees the client's SSPI accepts the challenge
+and advances to a Type 3 message; the handshake is never cryptographically
+validated by this test server."
+  (coerce
+   #(#x4e #x54 #x4c #x4d #x53 #x53 #x50 #x00 #x02 #x00 #x00 #x00 #x0c #x00 #x0c #x00
+     #x38 #x00 #x00 #x00 #x33 #x82 #x8a #xe2 #x01 #x23 #x45 #x67 #x89 #xab #xcd #xef
+     #x00 #x00 #x00 #x00 #x00 #x00 #x00 #x00 #x24 #x00 #x24 #x00 #x44 #x00 #x00 #x00
+     #x06 #x00 #x70 #x17 #x00 #x00 #x00 #x0f #x53 #x00 #x65 #x00 #x72 #x00 #x76 #x00
+     #x65 #x00 #x72 #x00 #x02 #x00 #x0c #x00 #x44 #x00 #x6f #x00 #x6d #x00 #x61 #x00
+     #x69 #x00 #x6e #x00 #x01 #x00 #x0c #x00 #x53 #x00 #x65 #x00 #x72 #x00 #x76 #x00
+     #x65 #x00 #x72 #x00 #x00 #x00 #x00 #x00)
+   '(vector (unsigned-byte 8))))
+
+(defstruct (ntlm-server (:constructor %make-ntlm-server))
+  socket
+  thread
+  port
+  ;; NTLM message types received, in order (expect (1 3) for a handshake).
+  (message-types nil))
+
+(defun crlf (stream)
+  (write-byte 13 stream)
+  (write-byte 10 stream))
+
+(defun write-ascii-line (stream string)
+  (loop for char across string
+        do (write-byte (char-code char) stream))
+  (crlf stream))
+
+(defun read-ascii-line (stream)
+  (let ((out (make-array 0 :element-type 'character :adjustable t :fill-pointer 0)))
+    (loop for byte = (read-byte stream nil nil)
+          do (cond ((null byte) (return-from read-ascii-line nil))
+                   ((= byte 10) (return))
+                   ((/= byte 13) (vector-push-extend (code-char byte) out))))
+    (coerce out 'simple-string)))
+
+(defun read-request-authorization (stream)
+  "Read one request head; return the Authorization header value (or NIL),
+or :EOF when the connection is gone."
+  (let ((first-line (read-ascii-line stream)))
+    (if (null first-line)
+        :eof
+        (loop with authorization = nil
+              for line = (read-ascii-line stream)
+              while (and line (plusp (length line)))
+              do (let ((colon (position #\: line)))
+                   (when (and colon (string-equal "authorization" (subseq line 0 colon)))
+                     (setf authorization (string-trim " " (subseq line (1+ colon))))))
+              finally (return authorization)))))
+
+(defun respond (stream status reason body &rest extra-headers)
+  (write-ascii-line stream (format nil "HTTP/1.1 ~D ~A" status reason))
+  (dolist (header extra-headers)
+    (write-ascii-line stream header))
+  (write-ascii-line stream (format nil "Content-Length: ~D" (length body)))
+  (write-ascii-line stream "Connection: keep-alive")
+  (crlf stream)
+  (loop for char across body
+        do (write-byte (char-code char) stream))
+  (force-output stream))
+
+(defun ntlm-token-type (authorization)
+  "NTLM message type of an \"NTLM <base64>\" Authorization value, or NIL."
+  (when (and authorization
+             (uiop:string-prefix-p "NTLM " authorization))
+    (let ((token (base64-string-to-usb8-array (subseq authorization 5))))
+      (when (<= 12 (length token))
+        (aref token 8)))))
+
+(defun handle-connection (server stream)
+  (loop
+    (let ((authorization (read-request-authorization stream)))
+      (when (eq authorization :eof)
+        (return))
+      (let ((message-type (ntlm-token-type authorization)))
+        (when message-type
+          (setf (ntlm-server-message-types server)
+                (append (ntlm-server-message-types server) (list message-type))))
+        (case message-type
+          ((nil)
+           (respond stream 401 "Unauthorized" "" "WWW-Authenticate: NTLM"))
+          (1
+           (respond stream 401 "Unauthorized" ""
+                    (format nil "WWW-Authenticate: NTLM ~A"
+                            (usb8-array-to-base64-string (type2-challenge-message)))))
+          (3
+           (respond stream 200 "OK" "SSO-OK"))
+          (t
+           (respond stream 400 "Bad Request" "")))))))
+
+(defun start-ntlm-server ()
+  (let* ((socket (usocket:socket-listen "127.0.0.1" 0 :element-type '(unsigned-byte 8)
+                                                      :reuse-address t))
+         (server (%make-ntlm-server :socket socket
+                                    :port (usocket:get-local-port socket))))
+    (setf (ntlm-server-thread server)
+          (bt2:make-thread
+           (lambda ()
+             (loop for client = (handler-case (usocket:socket-accept
+                                               socket :element-type '(unsigned-byte 8))
+                                  (error () (return)))
+                   while client
+                   do (unwind-protect
+                          (handler-case (handle-connection server (usocket:socket-stream client))
+                            (error (e) (warn "ntlm test server error: ~A" e)))
+                        (ignore-errors (usocket:socket-close client)))))
+           :name "ntlm test server"))
+    server))
+
+(defun stop-ntlm-server (server)
+  (ignore-errors (usocket:socket-close (ntlm-server-socket server)))
+  (ignore-errors (bt2:join-thread (ntlm-server-thread server)))
+  (values))
+
+(defmacro with-ntlm-server ((var) &body body)
+  `(let ((,var (start-ntlm-server)))
+     (unwind-protect
+         (progn ,@body)
+       (stop-ntlm-server ,var))))

--- a/t/proxy-server.lisp
+++ b/t/proxy-server.lisp
@@ -1,0 +1,219 @@
+(in-package :cl-user)
+(defpackage #:dexador-test.proxy
+  (:use #:cl)
+  (:import-from #:cl-base64
+                #:string-to-base64-string)
+  (:export #:start-test-proxy
+           #:stop-test-proxy
+           #:test-proxy-port
+           #:test-proxy-url
+           #:test-proxy-requests
+           #:with-test-proxy
+           #:+proxied-by-header+))
+(in-package #:dexador-test.proxy)
+
+;;; A minimal but strict HTTP/1.1 forward proxy for exercising dexador's
+;;; proxy support in the test suite, portably (including Windows).
+;;;
+;;; - Plain http requests must use the RFC 7230 absolute-form request target,
+;;;   otherwise the proxy answers 400. Forwarded responses get an
+;;;   "X-Proxied-By: <tag>" header injected so tests can tell proxied from
+;;;   direct responses.
+;;; - CONNECT establishes a blind tunnel (for https through the proxy).
+;;; - Optional Basic proxy authentication (407 challenge on failure).
+
+(alexandria:define-constant +proxied-by-header+ "x-proxied-by"
+  :test #'equal
+  :documentation "Response header the test proxy injects into forwarded responses.")
+
+(defstruct (test-proxy (:constructor %make-test-proxy))
+  socket
+  thread
+  port
+  tag
+  basic-auth
+  (requests nil)
+  (lock (bt2:make-lock :name "test proxy lock")))
+
+(defun record-request (proxy line)
+  (bt2:with-lock-held ((test-proxy-lock proxy))
+    (push line (test-proxy-requests proxy))))
+
+(defun test-proxy-url (proxy &key userinfo)
+  "Proxy URL, optionally with USERINFO credentials like \"user:pass\"."
+  (format nil "http://~@[~A@~]127.0.0.1:~D" userinfo (test-proxy-port proxy)))
+
+(defun crlf (stream)
+  (write-byte 13 stream)
+  (write-byte 10 stream))
+
+(defun write-ascii-line (stream string)
+  (loop for char across string
+        do (write-byte (char-code char) stream))
+  (crlf stream))
+
+(defun read-ascii-line (stream)
+  "Read one CRLF-terminated header line from a binary stream, or NIL at EOF."
+  (let ((out (make-array 0 :element-type 'character :adjustable t :fill-pointer 0)))
+    (loop for byte = (read-byte stream nil nil)
+          do (cond ((null byte) (return-from read-ascii-line nil))
+                   ((= byte 10) (return))
+                   ((/= byte 13) (vector-push-extend (code-char byte) out))))
+    (coerce out 'simple-string)))
+
+(defun read-head (stream)
+  "Read a request/response head. Returns (VALUES first-line headers-alist)."
+  (let ((first-line (read-ascii-line stream)))
+    (when first-line
+      (values first-line
+              (loop for line = (read-ascii-line stream)
+                    while (and line (plusp (length line)))
+                    for colon = (position #\: line)
+                    when colon
+                      collect (cons (string-downcase (subseq line 0 colon))
+                                    (string-trim " " (subseq line (1+ colon)))))))))
+
+(defun send-simple-response (stream status reason &rest extra-headers)
+  (write-ascii-line stream (format nil "HTTP/1.1 ~D ~A" status reason))
+  (dolist (header extra-headers)
+    (write-ascii-line stream header))
+  (write-ascii-line stream "Content-Length: 0")
+  (write-ascii-line stream "Connection: close")
+  (crlf stream)
+  (force-output stream))
+
+(defun authorized-p (proxy headers)
+  (let ((auth (test-proxy-basic-auth proxy)))
+    (or (null auth)
+        (equal (cdr (assoc "proxy-authorization" headers :test #'string=))
+               (format nil "Basic ~A"
+                       (string-to-base64-string
+                        (format nil "~A:~A" (car auth) (cdr auth))))))))
+
+(defun copy-until-eof (from to)
+  "Relay bytes FROM -> TO until EOF. Blocks for the first byte of each chunk
+only, so it also works for interactive CONNECT tunnels."
+  (loop with buffer = (make-array 4096 :element-type '(unsigned-byte 8))
+        for first = (read-byte from nil nil)
+        while first
+        do (setf (aref buffer 0) first)
+           (let ((end 1))
+             (loop while (and (< end (length buffer)) (listen from))
+                   for byte = (read-byte from nil nil)
+                   while byte
+                   do (setf (aref buffer end) byte)
+                      (incf end))
+             (write-sequence buffer to :end end)
+             (force-output to))))
+
+(defun forward-request (client method target version headers proxy)
+  "Forward an absolute-form request upstream; relay the response to CLIENT
+with an X-Proxied-By header injected."
+  (let* ((uri (quri:uri target))
+         (path (format nil "~A~@[?~A~]" (or (quri:uri-path uri) "/") (quri:uri-query uri))))
+    (usocket:with-client-socket (upstream stream (quri:uri-host uri) (quri:uri-port uri)
+                                          :element-type '(unsigned-byte 8))
+      (declare (ignorable upstream))
+      (write-ascii-line stream (format nil "~A ~A ~A" method path version))
+      (write-ascii-line stream (format nil "Host: ~A" (quri:uri-authority uri)))
+      (write-ascii-line stream "Connection: close")
+      ;; RFC 9110 7.6.3: a proxy MUST add Via to forwarded requests.
+      (write-ascii-line stream (format nil "Via: 1.1 ~A" (test-proxy-tag proxy)))
+      (loop for (name . value) in headers
+            unless (member name '("host" "connection" "proxy-connection" "proxy-authorization")
+                           :test #'string=)
+              do (write-ascii-line stream (format nil "~:(~A~): ~A" name value)))
+      (crlf stream)
+      ;; Forward a Content-Length body if the client sent one.
+      (let ((length (cdr (assoc "content-length" headers :test #'string=))))
+        (when (and length (plusp (parse-integer length)))
+          (let ((body (make-array (parse-integer length) :element-type '(unsigned-byte 8))))
+            (read-sequence body client)
+            (write-sequence body stream))))
+      (force-output stream)
+      ;; Relay the response, injecting the marker header and forcing the
+      ;; client connection closed (we serve one request per connection).
+      (multiple-value-bind (status-line response-headers) (read-head stream)
+        (write-ascii-line client status-line)
+        (write-ascii-line client (format nil "X-Proxied-By: ~A" (test-proxy-tag proxy)))
+        (loop for (name . value) in response-headers
+              unless (string= name "connection")
+                do (write-ascii-line client (format nil "~:(~A~): ~A" name value)))
+        (write-ascii-line client "Connection: close")
+        (crlf client)
+        ;; Flush the head now: bodiless responses (HEAD, 204...) never reach
+        ;; the copy loop, and usocket's socket-close doesn't flush.
+        (force-output client)
+        (copy-until-eof stream client)))))
+
+(defun establish-tunnel (client target)
+  "Handle CONNECT: open a TCP connection to TARGET (host:port) and relay
+bytes in both directions until either side closes."
+  (let* ((colon (position #\: target :from-end t))
+         (host (subseq target 0 colon))
+         (port (parse-integer (subseq target (1+ colon)))))
+    (usocket:with-client-socket (upstream stream host port :element-type '(unsigned-byte 8))
+      (declare (ignorable upstream))
+      (write-ascii-line client "HTTP/1.1 200 Connection Established")
+      (crlf client)
+      (force-output client)
+      (let ((up (bt2:make-thread (lambda ()
+                                   (ignore-errors (copy-until-eof client stream)))
+                                 :name "test proxy tunnel")))
+        (ignore-errors (copy-until-eof stream client))
+        (bt2:join-thread up)))))
+
+(defun handle-connection (proxy client)
+  (multiple-value-bind (first-line headers) (read-head client)
+    (when first-line
+      (record-request proxy first-line)
+      (destructuring-bind (method target &optional (version "HTTP/1.1"))
+          (uiop:split-string first-line :separator " ")
+        (cond
+          ((not (authorized-p proxy headers))
+           (send-simple-response client 407 "Proxy Authentication Required"
+                                 "Proxy-Authenticate: Basic realm=\"dexador-test\""))
+          ((string= method "CONNECT")
+           (establish-tunnel client target))
+          ;; A proxy must receive absolute-form targets (RFC 7230 5.3.2).
+          ((not (uiop:string-prefix-p "http://" target))
+           (send-simple-response client 400 "Bad Request"))
+          (t
+           (forward-request client method target version headers proxy)))))))
+
+(defun start-test-proxy (&key basic-auth (tag "cl-test-proxy"))
+  "Start an HTTP forward proxy on an ephemeral 127.0.0.1 port.
+BASIC-AUTH is an optional (\"user\" . \"pass\") cons the proxy requires."
+  (let* ((socket (usocket:socket-listen "127.0.0.1" 0 :element-type '(unsigned-byte 8)
+                                                      :reuse-address t))
+         (proxy (%make-test-proxy :socket socket
+                                  :port (usocket:get-local-port socket)
+                                  :tag tag
+                                  :basic-auth basic-auth)))
+    (setf (test-proxy-thread proxy)
+          (bt2:make-thread
+           (lambda ()
+             (loop for client-socket = (handler-case (usocket:socket-accept
+                                                      socket :element-type '(unsigned-byte 8))
+                                         (error () (return)))
+                   while client-socket
+                   do (unwind-protect
+                          (handler-case
+                              (handle-connection proxy (usocket:socket-stream client-socket))
+                            (error (e)
+                              (warn "test proxy error: ~A" e)))
+                        (ignore-errors (usocket:socket-close client-socket)))))
+           :name "test proxy acceptor"))
+    proxy))
+
+(defun stop-test-proxy (proxy)
+  (ignore-errors (usocket:socket-close (test-proxy-socket proxy)))
+  (ignore-errors (bt2:join-thread (test-proxy-thread proxy)))
+  (values))
+
+(defmacro with-test-proxy ((var &rest args &key basic-auth tag) &body body)
+  (declare (ignore basic-auth tag))
+  `(let ((,var (start-test-proxy ,@args)))
+     (unwind-protect
+         (progn ,@body)
+       (stop-test-proxy ,var))))


### PR DESCRIPTION
- Full support of proxy configuration: `:proxy` / `*default-proxy*` accept a scheme/host/`*` alist (most-specific wins); plain URL strings still work
- Seed `*default-proxy*` from `https_proxy` / `http_proxy` / `all_proxy`; if only one scheme proxy is set, use it for both HTTP and HTTPS
- Add `*no-proxy*` (from `NO_PROXY`) with hostname suffix matching plus IPv4/IPv6/CIDR matching
- Fix IPv6: strip brackets for usocket connect; match both bare and bracketed hosts in proxy alist keys
- Windows: WinHTTP proxy discovery + auth; integration tests (mitmproxy, NTLM, proxy server) and CI wiring
- Normalize string `:proxy` values to alist form at resolution time; docs/README updates

## Test plan

- [x] Unit tests for proxy resolution / `NO_PROXY` matching (incl. IPv6 keys)
- [x] Integration tests for Windows proxy discovery + NTLM auth
- [x] Smoke: `HTTP_PROXY` only proxies both schemes; per-scheme alist overrides as documented
